### PR TITLE
Disable dtrace support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "bunyan",
+  "name": "hexo-bunyan",
   "version": "2.0.0",
   "description": "a JSON logging library for node.js services",
   "author": "Trent Mick <trentm@gmail.com> (http://trentm.com)",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "// mv": "required for RotatingFileStream",
   "// moment": "required for local time with CLI",
   "optionalDependencies": {
-    "dtrace-provider": "~0.8",
     "mv": "~2",
     "safe-json-stringify": "~1",
     "moment": "^2.10.6"


### PR DESCRIPTION
Once this PR is landed, will do a cherry pick to 1.x branch. 

This should solve https://github.com/hexojs/hexo/issues/2506.

@NoahDragon Could you then publish the 1.x branch to npm so that hexo-log will change to use hexo-bunyan? Thank you.

