### PR TITLE
refactor: es6-fy & fit hexo code style

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,3 @@
+{
+    "extends": "hexo"
+}

--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -1,5 +1,3 @@
-/* eslint-disable one-var */
-
 /* eslint-disable strict */
 /*
   Logger class ( Logger() ) has a parameter `src` whose type is Boolean.
@@ -44,7 +42,8 @@ const assert = require('assert');
 const EventEmitter = require('events').EventEmitter;
 const stream = require('stream');
 
-let safeJsonStringify, mv;
+let safeJsonStringify, mv, RotatingFileStream;
+
 try {
   safeJsonStringify = require('safe-json-stringify');
 } catch (e) {
@@ -360,7 +359,6 @@ function Logger(options, _childOptions, _childSimple) {
 
 inherits(Logger, EventEmitter);
 
-let RotatingFileStream;
 if (!RotatingFileStream) RotatingFileStream = null;
 
 if (mv) {

--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -32,8 +32,8 @@ const INTERNAL_DEBUG = false; // Set this to true to enable internal dev/logging
 let xxx, safeJsonStringify, mv, RotatingFileStream;
 
 if (INTERNAL_DEBUG) {
-  xxx = (s) => { // internal dev/debug logging
-    const args = ['XXX: ' + s].concat(Array.prototype.slice.call(arguments, 1));
+  xxx = (s, ...rest) => {
+    const args = ['XXX: ' + s].concat(rest);
     console.error.apply(this, args);
   };
 } else {

--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -1,15 +1,14 @@
-/* eslint-disable no-mixed-operators */
-/* eslint-disable no-redeclare */
-/* eslint-disable no-use-before-define */
-/* eslint-disable block-scoped-var */
 /* eslint-disable one-var */
-// Should be removed after refactor
 
 /* eslint-disable strict */
-// Disable strict to pass the 'npm test'
-/* global window */
-// Add window to global to pass the eslint.
+/*
+  Logger class ( Logger() ) has a parameter `src` whose type is Boolean.
+  The src parameter is used to enable 'src' automatic field with log call source info.
+  So there will be a conversion to this.src: Boolean => String.
+  Thus, when strict mode is enabled, the src.test.js won't pass.
 
+  To enable strict mode, a breaking change (add a separate option under Logger class) is needed to bypass that conversion.
+*/
 
 /**
  * Copyright (c) 2017 Trent Mick.
@@ -37,62 +36,17 @@ let xxx = (s) => { // internal dev/debug logging
 };
 xxx = () => {}; // comment out to turn on debug logging
 
+let os = require('os');
+let fs = require('fs');
+let dtrace;
 
-/*
- * Runtime environment notes:
- *
- * Bunyan is intended to run in a number of runtime environments. Here are
- * some notes on differences for those envs and how the code copes.
- *
- * - node.js: The primary target environment.
- * - NW.js: http://nwjs.io/  An *app* environment that feels like both a
- *   node env -- it has node-like globals (`process`, `global`) and
- *   browser-like globals (`window`, `navigator`). My *understanding* is that
- *   bunyan can operate as if this is vanilla node.js.
- * - browser: Failing the above, we sniff using the `window` global
- *   <https://developer.mozilla.org/en-US/docs/Web/API/Window/window>.
- *      - browserify: http://browserify.org/  A browser-targetting bundler of
- *        node.js deps. The runtime is a browser env, so can't use fs access,
- *        etc. Browserify's build looks for `require(<single-string>)` imports
- *        to bundle. For some imports it won't be able to handle, we "hide"
- *        from browserify with `require('frobshizzle')`.
- * - Other? Please open issues if things are broken.
- */
-let runtimeEnv;
-if (typeof process !== 'undefined' && process.versions) {
-  if (process.versions.nw) {
-    runtimeEnv = 'nw';
-  } else if (process.versions.node) {
-    runtimeEnv = 'node';
-  }
-}
-if (!runtimeEnv && typeof window !== 'undefined' && window.window === window) {
-  runtimeEnv = 'browser';
-}
-if (!runtimeEnv) {
-  throw new Error('unknown runtime environment');
-}
-
-
-let os, fs, dtrace;
-if (runtimeEnv === 'browser') {
-  os = {
-    hostname: function() {
-      return window.location.host;
-    }
-  };
-  fs = {};
+try {
+  // eslint-disable-next-line node/no-missing-require
+  dtrace = require('dtrace-provider');
+} catch (e) {
   dtrace = null;
-} else {
-  os = require('os');
-  fs = require('fs');
-  try {
-    // eslint-disable-next-line node/no-missing-require
-    dtrace = require('dtrace-provider');
-  } catch (e) {
-    dtrace = null;
-  }
 }
+
 const util = require('util');
 const assert = require('assert');
 const EventEmitter = require('events').EventEmitter;
@@ -124,6 +78,26 @@ try {
 
 
 // ---- Internal support stuff
+
+// ---- Levels
+
+const TRACE = 10;
+const DEBUG = 20;
+const INFO = 30;
+const WARN = 40;
+const ERROR = 50;
+const FATAL = 60;
+
+const levelFromName = {
+  'trace': TRACE,
+  'debug': DEBUG,
+  'info': INFO,
+  'warn': WARN,
+  'error': ERROR,
+  'fatal': FATAL
+};
+let nameFromLevel = {};
+Object.assign(nameFromLevel, levelFromName);
 
 /**
  * A shallow copy of an object. Bunyan logging attempts to never cause
@@ -190,6 +164,11 @@ function _indent(s, indent) {
  * @param dedupKey {String} Optional. A short string key for this warning to
  *      have its warning only printed once.
  */
+
+let _warned;
+
+if (!_warned) _warned = {};
+
 function _warn(msg, dedupKey) {
   assert.ok(msg);
   if (dedupKey) {
@@ -201,8 +180,6 @@ function _warn(msg, dedupKey) {
 function _haveWarned(dedupKey) {
   return _warned[dedupKey];
 }
-let _warned = {};
-
 
 function ConsoleRawStream() {}
 ConsoleRawStream.prototype.write = (rec) => {
@@ -217,26 +194,6 @@ ConsoleRawStream.prototype.write = (rec) => {
   }
 };
 
-
-// ---- Levels
-
-const TRACE = 10,
-  DEBUG = 20,
-  INFO = 30,
-  WARN = 40,
-  ERROR = 50,
-  FATAL = 60;
-
-const levelFromName = {
-  'trace': TRACE,
-  'debug': DEBUG,
-  'info': INFO,
-  'warn': WARN,
-  'error': ERROR,
-  'fatal': FATAL
-};
-let nameFromLevel = {};
-Object.assign(nameFromLevel, levelFromName);
 
 // Dtrace probes.
 // eslint-disable-next-line no-undef-init
@@ -329,7 +286,7 @@ function Logger(options, _childOptions, _childSimple) {
   if (!parent) {
     if (!options.name) throw new TypeError('options.name (string) is required');
   } else {
-    if (options.name)  throw new TypeError('invalid options.name: child cannot set logger name');
+    if (options.name) throw new TypeError('invalid options.name: child cannot set logger name');
   }
   if (options.stream && options.streams) {
     throw new TypeError('cannot mix "streams" and "stream" options');
@@ -365,7 +322,7 @@ function Logger(options, _childOptions, _childSimple) {
     this._level = parent._level;
     this.streams = [];
     for (const i of parent.streams) {
-      let s = objCopy(i);
+      const s = objCopy(i);
       s.closeOnExit = false; // Don't own parent stream.
       this.streams.push(s);
     }
@@ -412,29 +369,12 @@ function Logger(options, _childOptions, _childSimple) {
   } else if (parent && options.level) {
     this.level(options.level);
   } else if (!parent) {
-    if (runtimeEnv === 'browser') {
-
-      /*
-       * In the browser we'll be emitting to console.log by default.
-       * Any console.log worth its salt these days can nicely render
-       * and introspect objects (e.g. the Firefox and Chrome console)
-       * so let's emit the raw log record. Are there browsers for which
-       * that breaks things?
-       */
-      self.addStream({
-        type: 'raw',
-        stream: new ConsoleRawStream(),
-        closeOnExit: false,
-        level: options.level
-      });
-    } else {
-      self.addStream({
-        type: 'stream',
-        stream: process.stdout,
-        closeOnExit: false,
-        level: options.level
-      });
-    }
+    self.addStream({
+      type: 'stream',
+      stream: process.stdout,
+      closeOnExit: false,
+      level: options.level
+    });
   }
   if (options.serializers) self.addSerializers(options.serializers);
   if (options.src) this.src = true;
@@ -464,6 +404,337 @@ function Logger(options, _childOptions, _childSimple) {
 
 util.inherits(Logger, EventEmitter);
 
+let RotatingFileStream;
+if (!RotatingFileStream) RotatingFileStream = null;
+
+if (mv) {
+  RotatingFileStream = function(options) {
+    this.path = options.path;
+    this.count = options.count == null ? 10 : options.count;
+    assert.equal(
+      typeof this.count,
+      'number',
+      `rotating-file stream "count" is not a number: ${this.count} (${typeof this.count}) in ${this}`
+    );
+    assert.ok(
+      this.count >= 0,
+      `rotating-file stream "count" is not >= 0: ${this.count} in ${this}`
+    );
+
+    // Parse `options.period`.
+    if (options.period) {
+      // <number><scope> where scope is:
+      //    h   hours (at the start of the hour)
+      //    d   days (at the start of the day, i.e. just after midnight)
+      //    w   weeks (at the start of Sunday)
+      //    m   months (on the first of the month)
+      //    y   years (at the start of Jan 1st)
+      // with special values 'hourly' (1h), 'daily' (1d), "weekly" (1w),
+      // 'monthly' (1m) and 'yearly' (1y)
+      const period = {
+        'hourly': '1h',
+        'daily': '1d',
+        'weekly': '1w',
+        'monthly': '1m',
+        'yearly': '1y'
+      }[options.period] || options.period;
+      const m = /^([1-9][0-9]*)([hdwmy]|ms)$/.exec(period);
+      if (!m) throw new Error(`invalid period: "${options.period}"`);
+
+      this.periodNum = Number(m[1]);
+      this.periodScope = m[2];
+    } else {
+      this.periodNum = 1;
+      this.periodScope = 'd';
+    }
+
+    let lastModified = null;
+    try {
+      const fileInfo = fs.statSync(this.path);
+      lastModified = fileInfo.mtime.getTime();
+    } catch (err) {
+      // file doesn't exist
+    }
+    let rotateAfterOpen = false;
+    if (lastModified) {
+      const lastRotTime = this._calcRotTime(0);
+      if (lastModified < lastRotTime) {
+        rotateAfterOpen = true;
+      }
+    }
+
+    // TODO: template support for backup files
+    // template: <path to which to rotate>
+    //      default is %P.%n
+    //      '/var/log/archive/foo.log'  -> foo.log.%n
+    //      '/var/log/archive/foo.log.%n'
+    //      codes:
+    //          XXX support strftime codes (per node version of those)
+    //              or whatever module. Pick non-colliding for extra
+    //              codes
+    //          %P      `path` base value
+    //          %n      integer number of rotated log (1,2,3,...)
+    //          %d      datetime in YYYY-MM-DD_HH-MM-SS
+    //                      XXX what should default date format be?
+    //                          prior art? Want to avoid ':' in
+    //                          filenames (illegal on Windows for one).
+
+    this.stream = fs.createWriteStream(this.path, { flags: 'a', encoding: 'utf8' });
+
+    this.rotQueue = [];
+    this.rotating = false;
+    if (rotateAfterOpen) {
+      this._debug('rotateAfterOpen -> call rotate()');
+      this.rotate();
+    } else {
+      this._setupNextRot();
+    }
+  };
+
+  util.inherits(RotatingFileStream, EventEmitter);
+
+  RotatingFileStream.prototype._debug = () => {
+    // Set this to `true` to add debug logging.
+    // eslint-disable-next-line no-constant-condition
+    if (false) {
+      if (arguments.length === 0) {
+        return true;
+      }
+      var args = Array.prototype.slice.call(arguments);
+      args[0] = '[' + new Date().toISOString() + ', '
+            + this.path + '] ' + args[0];
+      console.log.apply(this, args);
+    } else {
+      return false;
+    }
+  };
+
+  RotatingFileStream.prototype._setupNextRot = function() {
+    this.rotAt = this._calcRotTime(1);
+    this._setRotationTimer();
+  };
+
+  RotatingFileStream.prototype._setRotationTimer = function() {
+    const self = this;
+    let delay = this.rotAt - Date.now();
+    // Cap timeout to Node's max setTimeout, see
+    // <https://github.com/joyent/node/issues/8656>.
+    const TIMEOUT_MAX = 2147483647; // 2^31-1
+    if (delay > TIMEOUT_MAX) {
+      delay = TIMEOUT_MAX;
+    }
+    this.timeout = setTimeout(
+      () => {
+        self._debug('_setRotationTimer timeout -> call rotate()');
+        self.rotate();
+      },
+      delay
+    );
+    if (typeof this.timeout.unref === 'function') {
+      this.timeout.unref();
+    }
+  };
+
+  RotatingFileStream.prototype._calcRotTime = function _calcRotTime(periodOffset) {
+    this._debug(`_calcRotTime: ${this.periodNum}${this.periodScope}`);
+    const d = new Date();
+
+    this._debug(`  now local: ${d}`);
+    this._debug(`    now utc: ${d.toISOString()}`);
+    let rotAt;
+    switch (this.periodScope) {
+      case 'ms':
+      // Hidden millisecond period for debugging.
+        if (this.rotAt) {
+          rotAt = this.rotAt + (this.periodNum * periodOffset);
+        } else {
+          rotAt = Date.now() + (this.periodNum * periodOffset);
+        }
+        break;
+      case 'h':
+        if (this.rotAt) {
+          rotAt = this.rotAt + (this.periodNum * 60 * 60 * 1000 * periodOffset);
+        } else {
+        // First time: top of the next hour.
+          rotAt = Date.UTC(
+            d.getUTCFullYear(),
+            d.getUTCMonth(),
+            d.getUTCDate(),
+            d.getUTCHours() + periodOffset
+          );
+        }
+        break;
+      case 'd':
+        if (this.rotAt) {
+          rotAt = this.rotAt + (this.periodNum * 24 * 60 * 60 * 1000 * periodOffset);
+        } else {
+        // First time: start of tomorrow (i.e. at the coming midnight) UTC.
+          rotAt = Date.UTC(
+            d.getUTCFullYear(),
+            d.getUTCMonth(),
+            d.getUTCDate() + periodOffset
+          );
+        }
+        break;
+      case 'w':
+      // Currently, always on Sunday morning at 00:00:00 (UTC).
+        if (this.rotAt) {
+          rotAt = this.rotAt + (this.periodNum * 7 * 24 * 60 * 60 * 1000 * periodOffset);
+        } else {
+        // First time: this coming Sunday.
+          let dayOffset = 7 - d.getUTCDay();
+          if (periodOffset < 1) {
+            dayOffset = -d.getUTCDay();
+          }
+          if (periodOffset > 1 || periodOffset < -1) {
+            dayOffset += 7 * periodOffset;
+          }
+          rotAt = Date.UTC(
+            d.getUTCFullYear(),
+            d.getUTCMonth(),
+            d.getUTCDate() + dayOffset
+          );
+        }
+        break;
+      case 'm':
+        if (this.rotAt) {
+          rotAt = Date.UTC(
+            d.getUTCFullYear(),
+            d.getUTCMonth() + (this.periodNum * periodOffset),
+            1
+          );
+        } else {
+        // First time: the start of the next month.
+          rotAt = Date.UTC(
+            d.getUTCFullYear(),
+            d.getUTCMonth() + periodOffset,
+            1
+          );
+        }
+        break;
+      case 'y':
+        if (this.rotAt) {
+          rotAt = Date.UTC(
+            d.getUTCFullYear() + (this.periodNum * periodOffset),
+            0,
+            1
+          );
+        } else {
+        // First time: the start of the next year.
+          rotAt = Date.UTC(
+            d.getUTCFullYear() + periodOffset,
+            0,
+            1
+          );
+        }
+        break;
+      default:
+        assert.fail(`invalid period scope: "${this.periodScope}"`);
+    }
+
+    if (this._debug()) {
+      this._debug(`  **rotAt**: ${rotAt} (utc: ${new Date(rotAt).toUTCString()})`);
+      const now = Date.now();
+      this._debug(`        now: ${now} (${rotAt - now}ms == ${(rotAt - now) / 1000 / 60}min == ${(rotAt - now) / 1000 / 60 / 60}h to go)`);
+    }
+    return rotAt;
+  };
+
+  RotatingFileStream.prototype.rotate = function rotate() {
+    // XXX What about shutdown?
+    const self = this;
+
+    // If rotation period is > ~25 days, we have to break into multiple
+    // setTimeout's. See <https://github.com/joyent/node/issues/8656>.
+    if (self.rotAt && self.rotAt > Date.now()) return self._setRotationTimer();
+
+    this._debug('rotate');
+    if (self.rotating) {
+      throw new TypeError('cannot start a rotation when already rotating');
+    }
+    self.rotating = true;
+
+    self.stream.end(); // XXX can do moves sync after this? test at high rate
+
+    function del(n) {
+      let toDel = self.path + '.' + String(n - 1);
+      if (n === 0) {
+        toDel = self.path;
+      }
+      n -= 1;
+      self._debug(`  rm ${toDel}`);
+      fs.unlink(toDel, (delErr) => {
+        // XXX handle err other than not exists
+        moves(n);
+      });
+    }
+
+    function moves(n) {
+      if (self.count === 0 || n < 0) {
+        return finish();
+      }
+      let before = self.path;
+      const after = self.path + '.' + String(n);
+      if (n > 0) {
+        before += '.' + String(n - 1);
+      }
+      n -= 1;
+      // eslint-disable-next-line node/no-deprecated-api
+      fs.exists(before, (exists) => {
+        if (!exists) {
+          moves(n);
+        } else {
+          self._debug(`  mv ${before} ${after}`);
+          mv(before, after, (mvErr) => {
+            if (mvErr) {
+              self.emit('error', mvErr);
+              finish(); // XXX finish here?
+            } else {
+              moves(n);
+            }
+          });
+        }
+      });
+    }
+
+    function finish() {
+      self._debug(`  open ${self.path}`);
+      self.stream = fs.createWriteStream(self.path, { flags: 'a', encoding: 'utf8' });
+
+      for (const q of self.rotQueue) {
+        self.stream.write(q);
+      }
+      self.rotQueue = [];
+      self.rotating = false;
+      self.emit('drain');
+      self._setupNextRot();
+    }
+
+    let n = this.count;
+    del(n);
+  };
+
+  RotatingFileStream.prototype.write = function(s) {
+    if (this.rotating) {
+      this.rotQueue.push(s);
+      return false;
+    }
+    return this.stream.write(s);
+  };
+
+  RotatingFileStream.prototype.end = function(s) {
+    this.stream.end();
+  };
+
+  RotatingFileStream.prototype.destroy = function destroy(s) {
+    this.stream.destroy();
+  };
+
+  RotatingFileStream.prototype.destroySoon = function destroySoon(s) {
+    this.stream.destroySoon();
+  };
+
+} /* if (mv) */
 
 /**
  * Add a stream
@@ -768,9 +1039,9 @@ Logger.prototype._applySerializers = function(fields, excludeFields) {
     try {
       fields[name] = self.serializers[name](fields[name]);
     } catch (err) {
-      _warn(`bunyan: ERROR: Exception thrown from the "${name}" Bunyan serializer. This should never happen. This is a bug in that serializer function.\n${err.stack || err}`)
+      _warn(`bunyan: ERROR: Exception thrown from the "${name}" Bunyan serializer. This should never happen. This is a bug in that serializer function.\n${err.stack || err}`);
 
-      fields[name] = `(Error in Bunyan log "${name}" serializer broke field. See stderr for details.)`
+      fields[name] = `(Error in Bunyan log "${name}" serializer broke field. See stderr for details.)`;
     }
   });
 };
@@ -825,12 +1096,12 @@ function mkRecord(log, minLevel, args) {
     // `log.<level>(err, ...)`
     fields = {
       // Use this Logger's err serializer, if defined.
-      err: (log.serializers && log.serializers.err)
+      err: log.serializers && log.serializers.err
         ? log.serializers.err(args[0])
         : Logger.stdSerializers.err(args[0])
     };
     excludeFields = { err: true };
-    msgArgs = (args.length === 1) ? [fields.err.message] : args.slice(1);
+    msgArgs = args.length === 1 ? [fields.err.message] : args.slice(1);
   } else if (typeof args[0] !== 'object' || Array.isArray(args[0])) {
     // `log.<level>(msg, ...)`
     fields = null;
@@ -1084,337 +1355,6 @@ function fastAndSafeJsonStringify(rec) {
     }
   }
 }
-
-
-let RotatingFileStream = null;
-if (mv) {
-  RotatingFileStream = function(options) {
-    this.path = options.path;
-    this.count = options.count == null ? 10 : options.count;
-    assert.equal(
-      typeof this.count,
-      'number',
-      `rotating-file stream "count" is not a number: ${this.count} (${typeof this.count}) in ${this}`
-    );
-    assert.ok(
-      this.count >= 0,
-      `rotating-file stream "count" is not >= 0: ${this.count} in ${this}`
-    );
-
-    // Parse `options.period`.
-    if (options.period) {
-      // <number><scope> where scope is:
-      //    h   hours (at the start of the hour)
-      //    d   days (at the start of the day, i.e. just after midnight)
-      //    w   weeks (at the start of Sunday)
-      //    m   months (on the first of the month)
-      //    y   years (at the start of Jan 1st)
-      // with special values 'hourly' (1h), 'daily' (1d), "weekly" (1w),
-      // 'monthly' (1m) and 'yearly' (1y)
-      const period = {
-        'hourly': '1h',
-        'daily': '1d',
-        'weekly': '1w',
-        'monthly': '1m',
-        'yearly': '1y'
-      }[options.period] || options.period;
-      const m = /^([1-9][0-9]*)([hdwmy]|ms)$/.exec(period);
-      if (!m) throw new Error(`invalid period: "${options.period}"`);
-
-      this.periodNum = Number(m[1]);
-      this.periodScope = m[2];
-    } else {
-      this.periodNum = 1;
-      this.periodScope = 'd';
-    }
-
-    let lastModified = null;
-    try {
-      const fileInfo = fs.statSync(this.path);
-      lastModified = fileInfo.mtime.getTime();
-    } catch (err) {
-      // file doesn't exist
-    }
-    let rotateAfterOpen = false;
-    if (lastModified) {
-      const lastRotTime = this._calcRotTime(0);
-      if (lastModified < lastRotTime) {
-        rotateAfterOpen = true;
-      }
-    }
-
-    // TODO: template support for backup files
-    // template: <path to which to rotate>
-    //      default is %P.%n
-    //      '/var/log/archive/foo.log'  -> foo.log.%n
-    //      '/var/log/archive/foo.log.%n'
-    //      codes:
-    //          XXX support strftime codes (per node version of those)
-    //              or whatever module. Pick non-colliding for extra
-    //              codes
-    //          %P      `path` base value
-    //          %n      integer number of rotated log (1,2,3,...)
-    //          %d      datetime in YYYY-MM-DD_HH-MM-SS
-    //                      XXX what should default date format be?
-    //                          prior art? Want to avoid ':' in
-    //                          filenames (illegal on Windows for one).
-
-    this.stream = fs.createWriteStream(this.path, { flags: 'a', encoding: 'utf8' });
-
-    this.rotQueue = [];
-    this.rotating = false;
-    if (rotateAfterOpen) {
-      this._debug('rotateAfterOpen -> call rotate()');
-      this.rotate();
-    } else {
-      this._setupNextRot();
-    }
-  };
-
-  util.inherits(RotatingFileStream, EventEmitter);
-
-  RotatingFileStream.prototype._debug = () => {
-    // Set this to `true` to add debug logging.
-    // eslint-disable-next-line no-constant-condition
-    if (false) {
-      if (arguments.length === 0) {
-        return true;
-      }
-      var args = Array.prototype.slice.call(arguments);
-      args[0] = '[' + new Date().toISOString() + ', '
-            + this.path + '] ' + args[0];
-      console.log.apply(this, args);
-    } else {
-      return false;
-    }
-  };
-
-  RotatingFileStream.prototype._setupNextRot = function() {
-    this.rotAt = this._calcRotTime(1);
-    this._setRotationTimer();
-  };
-
-  RotatingFileStream.prototype._setRotationTimer = function() {
-    const self = this;
-    let delay = this.rotAt - Date.now();
-    // Cap timeout to Node's max setTimeout, see
-    // <https://github.com/joyent/node/issues/8656>.
-    const TIMEOUT_MAX = 2147483647; // 2^31-1
-    if (delay > TIMEOUT_MAX) {
-      delay = TIMEOUT_MAX;
-    }
-    this.timeout = setTimeout(
-      () => {
-        self._debug('_setRotationTimer timeout -> call rotate()');
-        self.rotate();
-      },
-      delay
-    );
-    if (typeof this.timeout.unref === 'function') {
-      this.timeout.unref();
-    }
-  };
-
-  RotatingFileStream.prototype._calcRotTime = function _calcRotTime(periodOffset) {
-    this._debug(`_calcRotTime: ${this.periodNum}${this.periodScope}`);
-    const d = new Date();
-
-    this._debug(`  now local: ${d}`);
-    this._debug(`    now utc: ${d.toISOString()}`);
-    let rotAt;
-    switch (this.periodScope) {
-      case 'ms':
-      // Hidden millisecond period for debugging.
-        if (this.rotAt) {
-          rotAt = this.rotAt + this.periodNum * periodOffset;
-        } else {
-          rotAt = Date.now() + this.periodNum * periodOffset;
-        }
-        break;
-      case 'h':
-        if (this.rotAt) {
-          rotAt = this.rotAt + this.periodNum * 60 * 60 * 1000 * periodOffset;
-        } else {
-        // First time: top of the next hour.
-          rotAt = Date.UTC(
-            d.getUTCFullYear(),
-            d.getUTCMonth(),
-            d.getUTCDate(),
-            d.getUTCHours() + periodOffset
-          );
-        }
-        break;
-      case 'd':
-        if (this.rotAt) {
-          rotAt = this.rotAt + this.periodNum * 24 * 60 * 60 * 1000 * periodOffset;
-        } else {
-        // First time: start of tomorrow (i.e. at the coming midnight) UTC.
-          rotAt = Date.UTC(
-            d.getUTCFullYear(),
-            d.getUTCMonth(),
-            d.getUTCDate() + periodOffset
-          );
-        }
-        break;
-      case 'w':
-      // Currently, always on Sunday morning at 00:00:00 (UTC).
-        if (this.rotAt) {
-          rotAt = this.rotAt + this.periodNum * 7 * 24 * 60 * 60 * 1000 * periodOffset;
-        } else {
-        // First time: this coming Sunday.
-          let dayOffset = 7 - d.getUTCDay();
-          if (periodOffset < 1) {
-            dayOffset = -d.getUTCDay();
-          }
-          if (periodOffset > 1 || periodOffset < -1) {
-            dayOffset += 7 * periodOffset;
-          }
-          rotAt = Date.UTC(
-            d.getUTCFullYear(),
-            d.getUTCMonth(),
-            d.getUTCDate() + dayOffset
-          );
-        }
-        break;
-      case 'm':
-        if (this.rotAt) {
-          rotAt = Date.UTC(
-            d.getUTCFullYear(),
-            d.getUTCMonth() + this.periodNum * periodOffset,
-            1
-          );
-        } else {
-        // First time: the start of the next month.
-          rotAt = Date.UTC(
-            d.getUTCFullYear(),
-            d.getUTCMonth() + periodOffset,
-            1
-          );
-        }
-        break;
-      case 'y':
-        if (this.rotAt) {
-          rotAt = Date.UTC(
-            d.getUTCFullYear() + this.periodNum * periodOffset,
-            0,
-            1
-          );
-        } else {
-        // First time: the start of the next year.
-          rotAt = Date.UTC(
-            d.getUTCFullYear() + periodOffset,
-            0,
-            1
-          );
-        }
-        break;
-      default:
-        assert.fail(`invalid period scope: "${this.periodScope}"`);
-    }
-
-    if (this._debug()) {
-      this._debug(`  **rotAt**: ${rotAt} (utc: ${new Date(rotAt).toUTCString()})`);
-      const now = Date.now();
-      this._debug(`        now: ${now} (${rotAt - now}ms == ${(rotAt - now) / 1000 / 60}min == ${(rotAt - now) / 1000 / 60 / 60}h to go)`);
-    }
-    return rotAt;
-  };
-
-  RotatingFileStream.prototype.rotate = function rotate() {
-    // XXX What about shutdown?
-    const self = this;
-
-    // If rotation period is > ~25 days, we have to break into multiple
-    // setTimeout's. See <https://github.com/joyent/node/issues/8656>.
-    if (self.rotAt && self.rotAt > Date.now()) return self._setRotationTimer();
-
-    this._debug('rotate');
-    if (self.rotating) {
-      throw new TypeError('cannot start a rotation when already rotating');
-    }
-    self.rotating = true;
-
-    self.stream.end(); // XXX can do moves sync after this? test at high rate
-
-    function del() {
-      let toDel = self.path + '.' + String(n - 1);
-      if (n === 0) {
-        toDel = self.path;
-      }
-      n -= 1;
-      self._debug(`  rm ${toDel}`);
-      fs.unlink(toDel, function(delErr) {
-        // XXX handle err other than not exists
-        moves();
-      });
-    }
-
-    function moves() {
-      if (self.count === 0 || n < 0) {
-        return finish();
-      }
-      let before = self.path;
-      const after = self.path + '.' + String(n);
-      if (n > 0) {
-        before += '.' + String(n - 1);
-      }
-      n -= 1;
-      // eslint-disable-next-line node/no-deprecated-api
-      fs.exists(before, (exists) => {
-        if (!exists) {
-          moves();
-        } else {
-          self._debug(`  mv ${before} ${after}`);
-          mv(before, after, (mvErr) => {
-            if (mvErr) {
-              self.emit('error', mvErr);
-              finish(); // XXX finish here?
-            } else {
-              moves();
-            }
-          });
-        }
-      });
-    }
-
-    function finish() {
-      self._debug(`  open ${self.path}`);
-      self.stream = fs.createWriteStream(self.path, { flags: 'a', encoding: 'utf8' });
-
-      for (const q of self.rotQueue) {
-        self.stream.write(q);
-      }
-      self.rotQueue = [];
-      self.rotating = false;
-      self.emit('drain');
-      self._setupNextRot();
-    }
-
-    const n = this.count;
-    del();
-  };
-
-  RotatingFileStream.prototype.write = function(s) {
-    if (this.rotating) {
-      this.rotQueue.push(s);
-      return false;
-    }
-    return this.stream.write(s);
-  };
-
-  RotatingFileStream.prototype.end = function(s) {
-    this.stream.end();
-  };
-
-  RotatingFileStream.prototype.destroy = function destroy(s) {
-    this.stream.destroy();
-  };
-
-  RotatingFileStream.prototype.destroySoon = function destroySoon(s) {
-    this.stream.destroySoon();
-  };
-
-} /* if (mv) */
 
 /**
  * RingBuffer is a Writable Stream that just stores the last N records in

--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -47,7 +47,7 @@ try {
   dtrace = null;
 }
 
-const util = require('util');
+const { format, inspect, inherits } = require('util');
 const assert = require('assert');
 const EventEmitter = require('events').EventEmitter;
 const stream = require('stream');
@@ -96,15 +96,14 @@ const levelFromName = {
   'error': ERROR,
   'fatal': FATAL
 };
-let nameFromLevel = {};
-Object.assign(nameFromLevel, levelFromName);
+const nameFromLevel = Object.assign({}, levelFromName);
 
 /**
  * A shallow copy of an object. Bunyan logging attempts to never cause
  * exceptions, so this function attempts to handle non-objects gracefully.
  */
 function objCopy(obj) {
-  if (obj == null) { // null or undefined
+  if (obj === null || obj === undefined) {
     return obj;
   } else if (Array.isArray(obj)) {
     return obj.slice();
@@ -114,8 +113,6 @@ function objCopy(obj) {
   }
   return obj;
 }
-
-const { format } = require('util');
 
 /**
  * Gather some caller info 3 stack levels up.
@@ -401,7 +398,7 @@ function Logger(options, _childOptions, _childSimple) {
   Object.assign(self.fields, fields);
 }
 
-util.inherits(Logger, EventEmitter);
+inherits(Logger, EventEmitter);
 
 let RotatingFileStream;
 if (!RotatingFileStream) RotatingFileStream = null;
@@ -490,18 +487,15 @@ if (mv) {
     }
   };
 
-  util.inherits(RotatingFileStream, EventEmitter);
+  inherits(RotatingFileStream, EventEmitter);
 
   RotatingFileStream.prototype._debug = () => {
     // Set this to `true` to add debug logging.
     // eslint-disable-next-line no-constant-condition
     if (false) {
-      if (arguments.length === 0) {
-        return true;
-      }
+      if (arguments.length === 0) return true;
       let args = Array.prototype.slice.call(arguments);
-      args[0] = '[' + new Date().toISOString() + ', '
-            + this.path + '] ' + args[0];
+      args[0] = `[${new Date().toISOString()}, ${this.path}] ${args[0]}`;
       console.log.apply(this, args);
     } else {
       return false;
@@ -519,9 +513,8 @@ if (mv) {
     // Cap timeout to Node's max setTimeout, see
     // <https://github.com/joyent/node/issues/8656>.
     const TIMEOUT_MAX = 2147483647; // 2^31-1
-    if (delay > TIMEOUT_MAX) {
-      delay = TIMEOUT_MAX;
-    }
+    if (delay > TIMEOUT_MAX) delay = TIMEOUT_MAX;
+
     this.timeout = setTimeout(
       () => {
         self._debug('_setRotationTimer timeout -> call rotate()');
@@ -779,7 +772,7 @@ Logger.prototype.addStream = function addStream(s, defaultLevel) {
 
   switch (s.type) {
     case 'stream':
-      assert.ok(isWritable(s.stream), '"stream" stream is not writable: ' + util.inspect(s.stream));
+      assert.ok(isWritable(s.stream), '"stream" stream is not writable: ' + inspect(s.stream));
 
       if (!s.closeOnExit) s.closeOnExit = false;
       break;
@@ -1110,7 +1103,7 @@ function mkRecord(log, minLevel, args) {
     // issue #35.
     fields = null;
     msgArgs = args.slice();
-    msgArgs[0] = util.inspect(msgArgs[0]);
+    msgArgs[0] = inspect(msgArgs[0]);
   } else { // `log.<level>(fields, msg, ...)`
     fields = args[0];
     if (fields && args.length === 1 && fields.err && fields.err instanceof Error) {
@@ -1173,7 +1166,7 @@ function mkLogEmitter(minLevel) {
       const dedupKey = 'unbound';
       if (!_haveWarned[dedupKey]) {
         const caller = getCaller3Info();
-        _warn(`bunyan usage error: ${caller.file}:${caller.line}: attempt to log with an unbound log method: \`this\` is: ${util.inspect(this)}`, dedupKey);
+        _warn(`bunyan usage error: ${caller.file}:${caller.line}: attempt to log with an unbound log method: \`this\` is: ${inspect(this)}`, dedupKey);
       }
       return;
     } else if (arguments.length === 0) { // `log.<level>()`
@@ -1345,7 +1338,7 @@ function fastAndSafeJsonStringify(rec) {
           + '`JSON.stringify(rec)`. You can install the '
           + '"safe-json-stringify" module to have Bunyan fallback '
           + 'to safer stringification. Record:\n'
-          + _indent(`${util.inspect(rec)}\n${e.stack}`),
+          + _indent(`${inspect(rec)}\n${e.stack}`),
         dedupKey
       );
       return `(Exception in JSON.stringify(rec): ${e.message}. See stderr for details.)`;
@@ -1369,7 +1362,7 @@ function RingBuffer(options) {
   EventEmitter.call(this);
 }
 
-util.inherits(RingBuffer, EventEmitter);
+inherits(RingBuffer, EventEmitter);
 
 RingBuffer.prototype.write = function(record) {
   if (!this.writable) throw new Error('RingBuffer has been ended already');

--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -52,7 +52,7 @@ const assert = require('assert');
 const EventEmitter = require('events').EventEmitter;
 const stream = require('stream');
 
-let safeJsonStringify, mv, sourceMapSupport;
+let safeJsonStringify, mv;
 try {
   safeJsonStringify = require('safe-json-stringify');
 } catch (e) {
@@ -68,14 +68,6 @@ try {
 } catch (e) {
   mv = null;
 }
-
-try {
-  // eslint-disable-next-line node/no-extraneous-require
-  sourceMapSupport = require('source-map-support');
-} catch (_) {
-  sourceMapSupport = null;
-}
-
 
 // ---- Internal support stuff
 
@@ -129,7 +121,6 @@ function getCaller3Info() {
 
   Error.prepareStackTrace = (_, stack) => {
     let caller = stack[2];
-    if (sourceMapSupport) caller = sourceMapSupport.wrapCallSite(caller);
 
     obj.file = caller.getFileName();
     obj.line = caller.getLineNumber();
@@ -161,9 +152,7 @@ function _indent(s, indent) {
  *      have its warning only printed once.
  */
 
-let _warned;
-
-if (!_warned) _warned = {};
+let _warned = {};
 
 function _warn(msg, dedupKey) {
   assert.ok(msg);
@@ -192,7 +181,6 @@ ConsoleRawStream.prototype.write = (rec) => {
 
 
 // Dtrace probes.
-// eslint-disable-next-line no-undef-init
 let dtp;
 const probes = dtrace && {};
 
@@ -338,12 +326,7 @@ function Logger(options, _childOptions, _childSimple) {
     dtp = dtrace.createDTraceProvider('bunyan');
 
     for (const level in levelFromName) {
-      let probe;
-
-      probes[levelFromName[level]] = probe = dtp.addProbe('log-' + level, 'char *');
-
-      // Explicitly add a reference to dtp to prevent it from being GC'd
-      probe.dtp = dtp;
+      probes[levelFromName[level]] = dtp.addProbe('log-' + level, 'char *');
     }
 
     dtp.enable();

--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -142,41 +142,7 @@ function objCopy(obj) {
   return obj;
 }
 
-
-const inspect = util.inspect;
-const formatRegExp = /%[sdj%]/g;
-const format = function format(f) {
-  if (typeof f !== 'string') {
-    let objects = [];
-    for (const argument of arguments) {
-      objects.push(inspect(argument));
-    }
-    return objects.join(' ');
-  }
-
-  let i = 1;
-  const args = arguments;
-  const len = args.length;
-  let str = String(f).replace(formatRegExp, (x) => {
-    if (i >= len) return x;
-    switch (x) {
-      case '%s': return String(args[i++]);
-      case '%d': return Number(args[i++]);
-      case '%j': return fastAndSafeJsonStringify(args[i++]);
-      case '%%': return '%';
-      default:
-        return x;
-    }
-  });
-  for (let x = args[i]; i < len; x = args[++i]) {
-    if (x === null || typeof x !== 'object') {
-      str += ' ' + x;
-    } else {
-      str += ' ' + inspect(x);
-    }
-  }
-  return str;
-};
+const { format } = require('util');
 
 /**
  * Gather some caller info 3 stack levels up.
@@ -290,12 +256,12 @@ function resolveLevel(nameOrNum) {
   if (type === 'string') {
     level = levelFromName[nameOrNum.toLowerCase()];
     if (!level) {
-      throw new Error(format('unknown level name: "%s"', nameOrNum));
+      throw new Error(`unknown level name: "${nameOrNum}"`);
     }
   } else if (type !== 'number') {
     throw new TypeError(format('cannot resolve level: invalid arg (%s):', type, nameOrNum));
   } else if (nameOrNum < 0 || Math.floor(nameOrNum) !== nameOrNum) {
-    throw new TypeError(format('level is not a positive integer: %s', nameOrNum));
+    throw new TypeError(`level is not a positive integer: ${nameOrNum}`);
   } else {
     level = nameOrNum;
   }
@@ -304,7 +270,7 @@ function resolveLevel(nameOrNum) {
 
 
 function isWritable(obj) {
-  if (obj instanceof stream.Writable)  return true;
+  if (obj instanceof stream.Writable) return true;
   return typeof obj.write === 'function';
 }
 
@@ -598,9 +564,7 @@ Logger.prototype.addSerializers = function addSerializers(serializers) {
   Object.keys(serializers).forEach((field) => {
     const serializer = serializers[field];
     if (typeof serializer !== 'function') {
-      throw new TypeError(
-        format('invalid serializer for "%s" field: must be a function', field)
-      );
+      throw new TypeError(`invalid serializer for "${field}" field: must be a function`);
     } else {
       self.serializers[field] = serializer;
     }
@@ -770,7 +734,7 @@ Logger.prototype.levels = function levels(name, value) {
         break;
       }
     }
-    if (!stream) throw new Error(format('no stream with name "%s"', name));
+    if (!stream) throw new Error(`no stream with name "${name}"`);
   }
   if (value === undefined) return stream.level;
 
@@ -804,16 +768,9 @@ Logger.prototype._applySerializers = function(fields, excludeFields) {
     try {
       fields[name] = self.serializers[name](fields[name]);
     } catch (err) {
-      _warn(
-        format(
-          'bunyan: ERROR: Exception thrown from the "%s" '
-          + 'Bunyan serializer. This should never happen. This is a bug '
-          + 'in that serializer function.\n%s',
-          name,
-          err.stack || err
-        )
-      );
-      fields[name] = format('(Error in Bunyan log "%s" serializer broke field. See stderr for details.)', name);
+      _warn(`bunyan: ERROR: Exception thrown from the "${name}" Bunyan serializer. This should never happen. This is a bug in that serializer function.\n${err.stack || err}`)
+
+      fields[name] = `(Error in Bunyan log "${name}" serializer broke field. See stderr for details.)`
     }
   });
 };
@@ -946,15 +903,7 @@ function mkLogEmitter(minLevel) {
       const dedupKey = 'unbound';
       if (!_haveWarned[dedupKey]) {
         const caller = getCaller3Info();
-        _warn(
-          format(
-            'bunyan usage error: %s:%s: attempt to log with an unbound log method: `this` is: %s',
-            caller.file,
-            caller.line,
-            util.inspect(this)
-          ),
-          dedupKey
-        );
+        _warn(`bunyan usage error: ${caller.file}:${caller.line}: attempt to log with an unbound log method: \`this\` is: ${util.inspect(this)}`, dedupKey);
       }
       return;
     } else if (arguments.length === 0) { // `log.<level>()`
@@ -1127,10 +1076,10 @@ function fastAndSafeJsonStringify(rec) {
           + '`JSON.stringify(rec)`. You can install the '
           + '"safe-json-stringify" module to have Bunyan fallback '
           + 'to safer stringification. Record:\n'
-          + _indent(format('%s\n%s', util.inspect(rec), e.stack)),
+          + _indent(`${util.inspect(rec)}\n${e.stack}`),
         dedupKey
       );
-      return format('(Exception in JSON.stringify(rec): %j. See stderr for details.)', e.message);
+      return `(Exception in JSON.stringify(rec): ${e.message}. See stderr for details.)`;
 
     }
   }
@@ -1145,20 +1094,11 @@ if (mv) {
     assert.equal(
       typeof this.count,
       'number',
-      format(
-        'rotating-file stream "count" is not a number: %j (%s) in %j',
-        this.count,
-        typeof this.count,
-        this
-      )
+      `rotating-file stream "count" is not a number: ${this.count} (${typeof this.count}) in ${this}`
     );
     assert.ok(
       this.count >= 0,
-      format(
-        'rotating-file stream "count" is not >= 0: %j in %j',
-        this.count,
-        this
-      )
+      `rotating-file stream "count" is not >= 0: ${this.count} in ${this}`
     );
 
     // Parse `options.period`.
@@ -1179,7 +1119,7 @@ if (mv) {
         'yearly': '1y'
       }[options.period] || options.period;
       const m = /^([1-9][0-9]*)([hdwmy]|ms)$/.exec(period);
-      if (!m) throw new Error(format('invalid period: "%s"', options.period));
+      if (!m) throw new Error(`invalid period: "${options.period}"`);
 
       this.periodNum = Number(m[1]);
       this.periodScope = m[2];
@@ -1276,11 +1216,11 @@ if (mv) {
   };
 
   RotatingFileStream.prototype._calcRotTime = function _calcRotTime(periodOffset) {
-    this._debug('_calcRotTime: %s%s', this.periodNum, this.periodScope);
+    this._debug(`_calcRotTime: ${this.periodNum}${this.periodScope}`);
     const d = new Date();
 
-    this._debug('  now local: %s', d);
-    this._debug('    now utc: %s', d.toISOString());
+    this._debug(`  now local: ${d}`);
+    this._debug(`    now utc: ${d.toISOString()}`);
     let rotAt;
     switch (this.periodScope) {
       case 'ms':
@@ -1369,17 +1309,13 @@ if (mv) {
         }
         break;
       default:
-        assert.fail(format('invalid period scope: "%s"', this.periodScope));
+        assert.fail(`invalid period scope: "${this.periodScope}"`);
     }
 
     if (this._debug()) {
-      this._debug('  **rotAt**: %s (utc: %s)', rotAt, new Date(rotAt).toUTCString());
+      this._debug(`  **rotAt**: ${rotAt} (utc: ${new Date(rotAt).toUTCString()})`);
       const now = Date.now();
-      this._debug('        now: %s (%sms == %smin == %sh to go)',
-        now,
-        rotAt - now,
-        (rotAt - now) / 1000 / 60,
-        (rotAt - now) / 1000 / 60 / 60);
+      this._debug(`        now: ${now} (${rotAt - now}ms == ${(rotAt - now) / 1000 / 60}min == ${(rotAt - now) / 1000 / 60 / 60}h to go)`);
     }
     return rotAt;
   };
@@ -1406,7 +1342,7 @@ if (mv) {
         toDel = self.path;
       }
       n -= 1;
-      self._debug('  rm %s', toDel);
+      self._debug(`  rm ${toDel}`);
       fs.unlink(toDel, function(delErr) {
         // XXX handle err other than not exists
         moves();
@@ -1424,11 +1360,11 @@ if (mv) {
       }
       n -= 1;
       // eslint-disable-next-line node/no-deprecated-api
-      fs.exists(before, (exists) =>{
+      fs.exists(before, (exists) => {
         if (!exists) {
           moves();
         } else {
-          self._debug('  mv %s %s', before, after);
+          self._debug(`  mv ${before} ${after}`);
           mv(before, after, (mvErr) => {
             if (mvErr) {
               self.emit('error', mvErr);
@@ -1442,7 +1378,7 @@ if (mv) {
     }
 
     function finish() {
-      self._debug('  open %s', self.path);
+      self._debug(`  open ${self.path}`);
       self.stream = fs.createWriteStream(self.path, { flags: 'a', encoding: 'utf8' });
 
       for (const q of self.rotQueue) {

--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -1,3 +1,16 @@
+/* eslint-disable no-mixed-operators */
+/* eslint-disable no-redeclare */
+/* eslint-disable no-use-before-define */
+/* eslint-disable block-scoped-var */
+/* eslint-disable one-var */
+// Should be removed after refactor
+
+/* eslint-disable strict */
+// Disable strict to pass the 'npm test'
+/* global window */
+// Add window to global to pass the eslint.
+
+
 /**
  * Copyright (c) 2017 Trent Mick.
  * Copyright (c) 2017 Joyent Inc.
@@ -18,12 +31,12 @@ var VERSION = '1.8.10';
 var LOG_VERSION = 0;
 
 
-var xxx = function xxx(s) {     // internal dev/debug logging
-    var args = ['XX' + 'X: '+s].concat(
-        Array.prototype.slice.call(arguments, 1));
-    console.error.apply(this, args);
+var xxx = function xxx(s) { // internal dev/debug logging
+  var args = ['XXX: ' + s].concat(
+    Array.prototype.slice.call(arguments, 1));
+  console.error.apply(this, args);
 };
-var xxx = function xxx() {};  // comment out to turn on debug logging
+xxx = function xxx() {}; // comment out to turn on debug logging
 
 
 /*
@@ -43,133 +56,133 @@ var xxx = function xxx() {};  // comment out to turn on debug logging
  *        node.js deps. The runtime is a browser env, so can't use fs access,
  *        etc. Browserify's build looks for `require(<single-string>)` imports
  *        to bundle. For some imports it won't be able to handle, we "hide"
- *        from browserify with `require('frobshizzle' + '')`.
+ *        from browserify with `require('frobshizzle')`.
  * - Other? Please open issues if things are broken.
  */
 var runtimeEnv;
-if (typeof (process) !== 'undefined' && process.versions) {
-    if (process.versions.nw) {
-        runtimeEnv = 'nw';
-    } else if (process.versions.node) {
-        runtimeEnv = 'node';
-    }
+if (typeof process !== 'undefined' && process.versions) {
+  if (process.versions.nw) {
+    runtimeEnv = 'nw';
+  } else if (process.versions.node) {
+    runtimeEnv = 'node';
+  }
 }
-if (!runtimeEnv && typeof (window) !== 'undefined' &&
-    window.window === window) {
-    runtimeEnv = 'browser';
+if (!runtimeEnv && typeof window !== 'undefined' && window.window === window) {
+  runtimeEnv = 'browser';
 }
 if (!runtimeEnv) {
-    throw new Error('unknown runtime environment');
+  throw new Error('unknown runtime environment');
 }
 
 
 var os, fs, dtrace;
 if (runtimeEnv === 'browser') {
-    os = {
-        hostname: function () {
-            return window.location.host;
-        }
-    };
-    fs = {};
-    dtrace = null;
-} else {
-    os = require('os');
-    fs = require('fs');
-    try {
-        dtrace = require('dtrace-provider' + '');
-    } catch (e) {
-        dtrace = null;
+  os = {
+    hostname: function() {
+      return window.location.host;
     }
+  };
+  fs = {};
+  dtrace = null;
+} else {
+  os = require('os');
+  fs = require('fs');
+  try {
+    // eslint-disable-next-line node/no-missing-require
+    dtrace = require('dtrace-provider');
+  } catch (e) {
+    dtrace = null;
+  }
 }
 var util = require('util');
 var assert = require('assert');
 var EventEmitter = require('events').EventEmitter;
 var stream = require('stream');
 
+var safeJsonStringify, mv, sourceMapSupport;
 try {
-    var safeJsonStringify = require('safe-json-stringify');
+  safeJsonStringify = require('safe-json-stringify');
 } catch (e) {
-    safeJsonStringify = null;
+  safeJsonStringify = null;
 }
 if (process.env.BUNYAN_TEST_NO_SAFE_JSON_STRINGIFY) {
-    safeJsonStringify = null;
+  safeJsonStringify = null;
 }
 
 // The 'mv' module is required for rotating-file stream support.
 try {
-    var mv = require('mv' + '');
+  mv = require('mv');
 } catch (e) {
-    mv = null;
+  mv = null;
 }
 
 try {
-    var sourceMapSupport = require('source-map-support' + '');
+  // eslint-disable-next-line node/no-extraneous-require
+  sourceMapSupport = require('source-map-support');
 } catch (_) {
-    sourceMapSupport = null;
+  sourceMapSupport = null;
 }
 
 
-//---- Internal support stuff
+// ---- Internal support stuff
 
 /**
  * A shallow copy of an object. Bunyan logging attempts to never cause
  * exceptions, so this function attempts to handle non-objects gracefully.
  */
 function objCopy(obj) {
-    if (obj == null) {  // null or undefined
-        return obj;
-    } else if (Array.isArray(obj)) {
-        return obj.slice();
-    } else if (typeof (obj) === 'object') {
-        var copy = {};
-        Object.keys(obj).forEach(function (k) {
-            copy[k] = obj[k];
-        });
-        return copy;
-    } else {
-        return obj;
-    }
+  if (obj == null) { // null or undefined
+    return obj;
+  } else if (Array.isArray(obj)) {
+    return obj.slice();
+  } else if (typeof obj === 'object') {
+    var copy = {};
+    Object.keys(obj).forEach(function(k) {
+      copy[k] = obj[k];
+    });
+    return copy;
+  }
+  return obj;
 }
 
 var format = util.format;
 if (!format) {
-    // If node < 0.6, then use its `util.format`:
-    // <https://github.com/joyent/node/blob/master/lib/util.js#L22>:
-    var inspect = util.inspect;
-    var formatRegExp = /%[sdj%]/g;
-    format = function format(f) {
-        if (typeof (f) !== 'string') {
-            var objects = [];
-            for (var i = 0; i < arguments.length; i++) {
-                objects.push(inspect(arguments[i]));
-            }
-            return objects.join(' ');
-        }
+  // If node < 0.6, then use its `util.format`:
+  // <https://github.com/joyent/node/blob/master/lib/util.js#L22>:
+  var inspect = util.inspect;
+  var formatRegExp = /%[sdj%]/g;
+  format = function format(f) {
+    if (typeof f !== 'string') {
+      var objects = [];
+      for (var i = 0; i < arguments.length; i++) {
+        objects.push(inspect(arguments[i]));
+      }
+      return objects.join(' ');
+    }
 
-        var i = 1;
-        var args = arguments;
-        var len = args.length;
-        var str = String(f).replace(formatRegExp, function (x) {
-            if (i >= len)
-                return x;
-            switch (x) {
-                case '%s': return String(args[i++]);
-                case '%d': return Number(args[i++]);
-                case '%j': return fastAndSafeJsonStringify(args[i++]);
-                case '%%': return '%';
-                default:
-                    return x;
-            }
-        });
-        for (var x = args[i]; i < len; x = args[++i]) {
-            if (x === null || typeof (x) !== 'object') {
-                str += ' ' + x;
-            } else {
-                str += ' ' + inspect(x);
-            }
-        }
-        return str;
-    };
+    var i = 1;
+    var args = arguments;
+    var len = args.length;
+    var str = String(f).replace(formatRegExp, function(x) {
+      if (i >= len) return x;
+      switch (x) {
+        case '%s': return String(args[i++]);
+        case '%d': return Number(args[i++]);
+        case '%j': return fastAndSafeJsonStringify(args[i++]);
+        case '%%': return '%';
+        default:
+          return x;
+      }
+    });
+    for (var x = args[i]; i < len; x = args[++i]) {
+      if (x === null || typeof x !== 'object') {
+        str += ' ' + x;
+      } else {
+        str += ' ' + inspect(x);
+      }
+    }
+    return str;
+  };
 }
 
 
@@ -178,39 +191,39 @@ if (!format) {
  * See <http://code.google.com/p/v8/wiki/JavaScriptStackTraceApi>.
  */
 function getCaller3Info() {
-    if (this === undefined) {
-        // Cannot access caller info in 'strict' mode.
-        return;
+  if (this === undefined) {
+    // Cannot access caller info in 'strict' mode.
+    return;
+  }
+  var obj = {};
+  var saveLimit = Error.stackTraceLimit;
+  var savePrepare = Error.prepareStackTrace;
+  Error.stackTraceLimit = 3;
+
+  Error.prepareStackTrace = function(_, stack) {
+    var caller = stack[2];
+    if (sourceMapSupport) {
+      caller = sourceMapSupport.wrapCallSite(caller);
     }
-    var obj = {};
-    var saveLimit = Error.stackTraceLimit;
-    var savePrepare = Error.prepareStackTrace;
-    Error.stackTraceLimit = 3;
+    obj.file = caller.getFileName();
+    obj.line = caller.getLineNumber();
+    var func = caller.getFunctionName();
+    if (func) obj.func = func;
+  };
+  Error.captureStackTrace(this, getCaller3Info);
+  // eslint-disable-next-line no-unused-expressions
+  this.stack;
 
-    Error.prepareStackTrace = function (_, stack) {
-        var caller = stack[2];
-        if (sourceMapSupport) {
-            caller = sourceMapSupport.wrapCallSite(caller);
-        }
-        obj.file = caller.getFileName();
-        obj.line = caller.getLineNumber();
-        var func = caller.getFunctionName();
-        if (func)
-            obj.func = func;
-    };
-    Error.captureStackTrace(this, getCaller3Info);
-    this.stack;
-
-    Error.stackTraceLimit = saveLimit;
-    Error.prepareStackTrace = savePrepare;
-    return obj;
+  Error.stackTraceLimit = saveLimit;
+  Error.prepareStackTrace = savePrepare;
+  return obj;
 }
 
 
 function _indent(s, indent) {
-    if (!indent) indent = '    ';
-    var lines = s.split(/\r?\n/g);
-    return indent + lines.join('\n' + indent);
+  if (!indent) indent = '    ';
+  var lines = s.split(/\r?\n/g);
+  return indent + lines.join('\n' + indent);
 }
 
 
@@ -222,36 +235,36 @@ function _indent(s, indent) {
  *      have its warning only printed once.
  */
 function _warn(msg, dedupKey) {
-    assert.ok(msg);
-    if (dedupKey) {
-        if (_warned[dedupKey]) {
-            return;
-        }
-        _warned[dedupKey] = true;
+  assert.ok(msg);
+  if (dedupKey) {
+    if (_warned[dedupKey]) {
+      return;
     }
-    process.stderr.write(msg + '\n');
+    _warned[dedupKey] = true;
+  }
+  process.stderr.write(msg + '\n');
 }
 function _haveWarned(dedupKey) {
-    return _warned[dedupKey];
+  return _warned[dedupKey];
 }
 var _warned = {};
 
 
 function ConsoleRawStream() {}
-ConsoleRawStream.prototype.write = function (rec) {
-    if (rec.level < INFO) {
-        console.log(rec);
-    } else if (rec.level < WARN) {
-        console.info(rec);
-    } else if (rec.level < ERROR) {
-        console.warn(rec);
-    } else {
-        console.error(rec);
-    }
+ConsoleRawStream.prototype.write = function(rec) {
+  if (rec.level < INFO) {
+    console.log(rec);
+  } else if (rec.level < WARN) {
+    console.info(rec);
+  } else if (rec.level < ERROR) {
+    console.warn(rec);
+  } else {
+    console.error(rec);
+  }
 };
 
 
-//---- Levels
+// ---- Levels
 
 var TRACE = 10;
 var DEBUG = 20;
@@ -261,19 +274,20 @@ var ERROR = 50;
 var FATAL = 60;
 
 var levelFromName = {
-    'trace': TRACE,
-    'debug': DEBUG,
-    'info': INFO,
-    'warn': WARN,
-    'error': ERROR,
-    'fatal': FATAL
+  'trace': TRACE,
+  'debug': DEBUG,
+  'info': INFO,
+  'warn': WARN,
+  'error': ERROR,
+  'fatal': FATAL
 };
 var nameFromLevel = {};
-Object.keys(levelFromName).forEach(function (name) {
-    nameFromLevel[levelFromName[name]] = name;
+Object.keys(levelFromName).forEach(function(name) {
+  nameFromLevel[levelFromName[name]] = name;
 });
 
 // Dtrace probes.
+// eslint-disable-next-line no-undef-init
 var dtp = undefined;
 var probes = dtrace && {};
 
@@ -285,35 +299,35 @@ var probes = dtrace && {};
  * @api public
  */
 function resolveLevel(nameOrNum) {
-    var level;
-    var type = typeof (nameOrNum);
-    if (type === 'string') {
-        level = levelFromName[nameOrNum.toLowerCase()];
-        if (!level) {
-            throw new Error(format('unknown level name: "%s"', nameOrNum));
-        }
-    } else if (type !== 'number') {
-        throw new TypeError(format('cannot resolve level: invalid arg (%s):',
-            type, nameOrNum));
-    } else if (nameOrNum < 0 || Math.floor(nameOrNum) !== nameOrNum) {
-        throw new TypeError(format('level is not a positive integer: %s',
-            nameOrNum));
-    } else {
-        level = nameOrNum;
+  var level;
+  var type = typeof nameOrNum;
+  if (type === 'string') {
+    level = levelFromName[nameOrNum.toLowerCase()];
+    if (!level) {
+      throw new Error(format('unknown level name: "%s"', nameOrNum));
     }
-    return level;
+  } else if (type !== 'number') {
+    throw new TypeError(format('cannot resolve level: invalid arg (%s):',
+      type, nameOrNum));
+  } else if (nameOrNum < 0 || Math.floor(nameOrNum) !== nameOrNum) {
+    throw new TypeError(format('level is not a positive integer: %s',
+      nameOrNum));
+  } else {
+    level = nameOrNum;
+  }
+  return level;
 }
 
 
 function isWritable(obj) {
-    if (obj instanceof stream.Writable) {
-        return true;
-    }
-    return typeof (obj.write) === 'function';
+  if (obj instanceof stream.Writable) {
+    return true;
+  }
+  return typeof obj.write === 'function';
 }
 
 
-//---- Logger class
+// ---- Logger class
 
 /**
  * Create a Logger instance.
@@ -351,181 +365,180 @@ function isWritable(obj) {
  *    creation.
  */
 function Logger(options, _childOptions, _childSimple) {
-    xxx('Logger start:', options)
-    if (!(this instanceof Logger)) {
-        return new Logger(options, _childOptions);
+  xxx('Logger start:', options);
+  if (!(this instanceof Logger)) {
+    return new Logger(options, _childOptions);
+  }
+
+  // Input arg validation.
+  var parent;
+  if (_childOptions !== undefined) {
+    parent = options;
+    options = _childOptions;
+    if (!(parent instanceof Logger)) {
+      throw new TypeError(
+        'invalid Logger creation: do not pass a second arg');
+    }
+  }
+  if (!options) {
+    throw new TypeError('options (object) is required');
+  }
+  if (!parent) {
+    if (!options.name) {
+      throw new TypeError('options.name (string) is required');
+    }
+  } else {
+    if (options.name) {
+      throw new TypeError(
+        'invalid options.name: child cannot set logger name');
+    }
+  }
+  if (options.stream && options.streams) {
+    throw new TypeError('cannot mix "streams" and "stream" options');
+  }
+  if (options.streams && !Array.isArray(options.streams)) {
+    throw new TypeError('invalid options.streams: must be an array');
+  }
+  if (options.serializers && (typeof options.serializers !== 'object' || Array.isArray(options.serializers))) {
+    throw new TypeError('invalid options.serializers: must be an object');
+  }
+
+  EventEmitter.call(this);
+
+  // Fast path for simple child creation.
+  if (parent && _childSimple) {
+    // `_isSimpleChild` is a signal to stream close handling that this child
+    // owns none of its streams.
+    this._isSimpleChild = true;
+
+    this._level = parent._level;
+    this.streams = parent.streams;
+    this.serializers = parent.serializers;
+    this.src = parent.src;
+    var fields = this.fields = {};
+    var parentFieldNames = Object.keys(parent.fields);
+    for (var i = 0; i < parentFieldNames.length; i++) {
+      var name = parentFieldNames[i];
+      fields[name] = parent.fields[name];
+    }
+    var names = Object.keys(options);
+    for (var i = 0; i < names.length; i++) {
+      var name = names[i];
+      fields[name] = options[name];
+    }
+    return;
+  }
+
+  // Start values.
+  var self = this;
+  if (parent) {
+    this._level = parent._level;
+    this.streams = [];
+    for (var i = 0; i < parent.streams.length; i++) {
+      var s = objCopy(parent.streams[i]);
+      s.closeOnExit = false; // Don't own parent stream.
+      this.streams.push(s);
+    }
+    this.serializers = objCopy(parent.serializers);
+    this.src = parent.src;
+    this.fields = objCopy(parent.fields);
+    if (options.level) {
+      this.level(options.level);
+    }
+  } else {
+    this._level = Number.POSITIVE_INFINITY;
+    this.streams = [];
+    this.serializers = null;
+    this.src = false;
+    this.fields = {};
+  }
+
+  if (!dtp && dtrace) {
+    dtp = dtrace.createDTraceProvider('bunyan');
+
+    for (var level in levelFromName) {
+      var probe;
+
+      probes[levelFromName[level]] = probe = dtp.addProbe('log-' + level, 'char *');
+
+      // Explicitly add a reference to dtp to prevent it from being GC'd
+      probe.dtp = dtp;
     }
 
-    // Input arg validation.
-    var parent;
-    if (_childOptions !== undefined) {
-        parent = options;
-        options = _childOptions;
-        if (!(parent instanceof Logger)) {
-            throw new TypeError(
-                'invalid Logger creation: do not pass a second arg');
-        }
-    }
-    if (!options) {
-        throw new TypeError('options (object) is required');
-    }
-    if (!parent) {
-        if (!options.name) {
-            throw new TypeError('options.name (string) is required');
-        }
-    } else {
-        if (options.name) {
-            throw new TypeError(
-                'invalid options.name: child cannot set logger name');
-        }
-    }
-    if (options.stream && options.streams) {
-        throw new TypeError('cannot mix "streams" and "stream" options');
-    }
-    if (options.streams && !Array.isArray(options.streams)) {
-        throw new TypeError('invalid options.streams: must be an array')
-    }
-    if (options.serializers && (typeof (options.serializers) !== 'object' ||
-            Array.isArray(options.serializers))) {
-        throw new TypeError('invalid options.serializers: must be an object')
-    }
+    dtp.enable();
+  }
 
-    EventEmitter.call(this);
+  // Handle *config* options (i.e. options that are not just plain data
+  // for log records).
+  if (options.stream) {
+    self.addStream({
+      type: 'stream',
+      stream: options.stream,
+      closeOnExit: false,
+      level: options.level
+    });
+  } else if (options.streams) {
+    options.streams.forEach(function(s) {
+      self.addStream(s, options.level);
+    });
+  } else if (parent && options.level) {
+    this.level(options.level);
+  } else if (!parent) {
+    if (runtimeEnv === 'browser') {
 
-    // Fast path for simple child creation.
-    if (parent && _childSimple) {
-        // `_isSimpleChild` is a signal to stream close handling that this child
-        // owns none of its streams.
-        this._isSimpleChild = true;
-
-        this._level = parent._level;
-        this.streams = parent.streams;
-        this.serializers = parent.serializers;
-        this.src = parent.src;
-        var fields = this.fields = {};
-        var parentFieldNames = Object.keys(parent.fields);
-        for (var i = 0; i < parentFieldNames.length; i++) {
-            var name = parentFieldNames[i];
-            fields[name] = parent.fields[name];
-        }
-        var names = Object.keys(options);
-        for (var i = 0; i < names.length; i++) {
-            var name = names[i];
-            fields[name] = options[name];
-        }
-        return;
-    }
-
-    // Start values.
-    var self = this;
-    if (parent) {
-        this._level = parent._level;
-        this.streams = [];
-        for (var i = 0; i < parent.streams.length; i++) {
-            var s = objCopy(parent.streams[i]);
-            s.closeOnExit = false; // Don't own parent stream.
-            this.streams.push(s);
-        }
-        this.serializers = objCopy(parent.serializers);
-        this.src = parent.src;
-        this.fields = objCopy(parent.fields);
-        if (options.level) {
-            this.level(options.level);
-        }
-    } else {
-        this._level = Number.POSITIVE_INFINITY;
-        this.streams = [];
-        this.serializers = null;
-        this.src = false;
-        this.fields = {};
-    }
-
-    if (!dtp && dtrace) {
-        dtp = dtrace.createDTraceProvider('bunyan');
-
-        for (var level in levelFromName) {
-            var probe;
-
-            probes[levelFromName[level]] = probe =
-                dtp.addProbe('log-' + level, 'char *');
-
-            // Explicitly add a reference to dtp to prevent it from being GC'd
-            probe.dtp = dtp;
-        }
-
-        dtp.enable();
-    }
-
-    // Handle *config* options (i.e. options that are not just plain data
-    // for log records).
-    if (options.stream) {
-        self.addStream({
-            type: 'stream',
-            stream: options.stream,
-            closeOnExit: false,
-            level: options.level
-        });
-    } else if (options.streams) {
-        options.streams.forEach(function (s) {
-            self.addStream(s, options.level);
-        });
-    } else if (parent && options.level) {
-        this.level(options.level);
-    } else if (!parent) {
-        if (runtimeEnv === 'browser') {
-            /*
+      /*
              * In the browser we'll be emitting to console.log by default.
              * Any console.log worth its salt these days can nicely render
              * and introspect objects (e.g. the Firefox and Chrome console)
              * so let's emit the raw log record. Are there browsers for which
              * that breaks things?
              */
-            self.addStream({
-                type: 'raw',
-                stream: new ConsoleRawStream(),
-                closeOnExit: false,
-                level: options.level
-            });
-        } else {
-            self.addStream({
-                type: 'stream',
-                stream: process.stdout,
-                closeOnExit: false,
-                level: options.level
-            });
-        }
+      self.addStream({
+        type: 'raw',
+        stream: new ConsoleRawStream(),
+        closeOnExit: false,
+        level: options.level
+      });
+    } else {
+      self.addStream({
+        type: 'stream',
+        stream: process.stdout,
+        closeOnExit: false,
+        level: options.level
+      });
     }
-    if (options.serializers) {
-        self.addSerializers(options.serializers);
-    }
-    if (options.src) {
-        this.src = true;
-    }
-    xxx('Logger: ', self)
+  }
+  if (options.serializers) {
+    self.addSerializers(options.serializers);
+  }
+  if (options.src) {
+    this.src = true;
+  }
+  xxx('Logger: ', self);
 
-    // Fields.
-    // These are the default fields for log records (minus the attributes
-    // removed in this constructor). To allow storing raw log records
-    // (unrendered), `this.fields` must never be mutated. Create a copy for
-    // any changes.
-    var fields = objCopy(options);
-    delete fields.stream;
-    delete fields.level;
-    delete fields.streams;
-    delete fields.serializers;
-    delete fields.src;
-    if (this.serializers) {
-        this._applySerializers(fields);
-    }
-    if (!fields.hostname && !self.fields.hostname) {
-        fields.hostname = os.hostname();
-    }
-    if (!fields.pid) {
-        fields.pid = process.pid;
-    }
-    Object.keys(fields).forEach(function (k) {
-        self.fields[k] = fields[k];
-    });
+  // Fields.
+  // These are the default fields for log records (minus the attributes
+  // removed in this constructor). To allow storing raw log records
+  // (unrendered), `this.fields` must never be mutated. Create a copy for
+  // any changes.
+  var fields = objCopy(options);
+  delete fields.stream;
+  delete fields.level;
+  delete fields.streams;
+  delete fields.serializers;
+  delete fields.src;
+  if (this.serializers) {
+    this._applySerializers(fields);
+  }
+  if (!fields.hostname && !self.fields.hostname) {
+    fields.hostname = os.hostname();
+  }
+  if (!fields.pid) {
+    fields.pid = process.pid;
+  }
+  Object.keys(fields).forEach(function(k) {
+    self.fields[k] = fields[k];
+  });
 }
 
 util.inherits(Logger, EventEmitter);
@@ -549,88 +562,88 @@ util.inherits(Logger, EventEmitter);
  *      `stream.level` is not set. If neither is given, this defaults to INFO.
  */
 Logger.prototype.addStream = function addStream(s, defaultLevel) {
-    var self = this;
-    if (defaultLevel === null || defaultLevel === undefined) {
-        defaultLevel = INFO;
-    }
+  var self = this;
+  if (defaultLevel === null || defaultLevel === undefined) {
+    defaultLevel = INFO;
+  }
 
-    s = objCopy(s);
+  s = objCopy(s);
 
-    // Implicit 'type' from other args.
-    if (!s.type) {
-        if (s.stream) {
-            s.type = 'stream';
-        } else if (s.path) {
-            s.type = 'file'
-        }
+  // Implicit 'type' from other args.
+  if (!s.type) {
+    if (s.stream) {
+      s.type = 'stream';
+    } else if (s.path) {
+      s.type = 'file';
     }
-    s.raw = (s.type === 'raw');  // PERF: Allow for faster check in `_emit`.
+  }
+  s.raw = s.type === 'raw'; // PERF: Allow for faster check in `_emit`.
 
-    if (s.level !== undefined) {
-        s.level = resolveLevel(s.level);
-    } else {
-        s.level = resolveLevel(defaultLevel);
-    }
-    if (s.level < self._level) {
-        self._level = s.level;
-    }
+  if (s.level !== undefined) {
+    s.level = resolveLevel(s.level);
+  } else {
+    s.level = resolveLevel(defaultLevel);
+  }
+  if (s.level < self._level) {
+    self._level = s.level;
+  }
 
-    switch (s.type) {
+  switch (s.type) {
     case 'stream':
-        assert.ok(isWritable(s.stream),
-                  '"stream" stream is not writable: ' + util.inspect(s.stream));
+      assert.ok(isWritable(s.stream),
+        '"stream" stream is not writable: ' + util.inspect(s.stream));
 
-        if (!s.closeOnExit) {
-            s.closeOnExit = false;
-        }
-        break;
+      if (!s.closeOnExit) {
+        s.closeOnExit = false;
+      }
+      break;
     case 'file':
-        if (s.reemitErrorEvents === undefined) {
-            s.reemitErrorEvents = true;
+      if (s.reemitErrorEvents === undefined) {
+        s.reemitErrorEvents = true;
+      }
+      if (!s.stream) {
+        s.stream = fs.createWriteStream(s.path,
+          {flags: 'a', encoding: 'utf8'});
+        if (!s.closeOnExit) {
+          s.closeOnExit = true;
         }
-        if (!s.stream) {
-            s.stream = fs.createWriteStream(s.path,
-                                            {flags: 'a', encoding: 'utf8'});
-            if (!s.closeOnExit) {
-                s.closeOnExit = true;
-            }
-        } else {
-            if (!s.closeOnExit) {
-                s.closeOnExit = false;
-            }
+      } else {
+        if (!s.closeOnExit) {
+          s.closeOnExit = false;
         }
-        break;
+      }
+      break;
     case 'rotating-file':
-        assert.ok(!s.stream,
-                  '"rotating-file" stream should not give a "stream"');
-        assert.ok(s.path);
-        assert.ok(mv, '"rotating-file" stream type is not supported: '
+      assert.ok(!s.stream,
+        '"rotating-file" stream should not give a "stream"');
+      assert.ok(s.path);
+      assert.ok(mv, '"rotating-file" stream type is not supported: '
                       + 'missing "mv" module');
-        s.stream = new RotatingFileStream(s);
-        if (!s.closeOnExit) {
-            s.closeOnExit = true;
-        }
-        break;
+      s.stream = new RotatingFileStream(s);
+      if (!s.closeOnExit) {
+        s.closeOnExit = true;
+      }
+      break;
     case 'raw':
-        if (!s.closeOnExit) {
-            s.closeOnExit = false;
-        }
-        break;
+      if (!s.closeOnExit) {
+        s.closeOnExit = false;
+      }
+      break;
     default:
-        throw new TypeError('unknown stream type "' + s.type + '"');
-    }
+      throw new TypeError('unknown stream type "' + s.type + '"');
+  }
 
-    if (s.reemitErrorEvents && typeof (s.stream.on) === 'function') {
-        // TODO: When we have `<logger>.close()`, it should remove event
-        //      listeners to not leak Logger instances.
-        s.stream.on('error', function onStreamError(err) {
-            self.emit('error', err, s);
-        });
-    }
+  if (s.reemitErrorEvents && typeof s.stream.on === 'function') {
+    // TODO: When we have `<logger>.close()`, it should remove event
+    //      listeners to not leak Logger instances.
+    s.stream.on('error', function onStreamError(err) {
+      self.emit('error', err, s);
+    });
+  }
 
-    self.streams.push(s);
-    delete self.haveNonRawStreams;  // reset
-}
+  self.streams.push(s);
+  delete self.haveNonRawStreams; // reset
+};
 
 
 /**
@@ -640,24 +653,22 @@ Logger.prototype.addStream = function addStream(s, defaultLevel) {
  *    to serializing functions. See README.md for details.
  */
 Logger.prototype.addSerializers = function addSerializers(serializers) {
-    var self = this;
+  var self = this;
 
-    if (!self.serializers) {
-        self.serializers = {};
+  if (!self.serializers) {
+    self.serializers = {};
+  }
+  Object.keys(serializers).forEach(function(field) {
+    var serializer = serializers[field];
+    if (typeof serializer !== 'function') {
+      throw new TypeError(format(
+        'invalid serializer for "%s" field: must be a function',
+        field));
+    } else {
+      self.serializers[field] = serializer;
     }
-    Object.keys(serializers).forEach(function (field) {
-        var serializer = serializers[field];
-        if (typeof (serializer) !== 'function') {
-            throw new TypeError(format(
-                'invalid serializer for "%s" field: must be a function',
-                field));
-        } else {
-            self.serializers[field] = serializer;
-        }
-    });
-}
-
-
+  });
+};
 
 /**
  * Create a child logger, typically to add a few log record fields.
@@ -685,9 +696,9 @@ Logger.prototype.addSerializers = function addSerializers(serializers) {
  *    required for them. IOW, this is a fast path for frequent child
  *    creation. See 'tools/timechild.js' for numbers.
  */
-Logger.prototype.child = function (options, simple) {
-    return new (this.constructor)(this, options || {}, simple);
-}
+Logger.prototype.child = function(options, simple) {
+  return new this.constructor(this, options || {}, simple);
+};
 
 
 /**
@@ -707,24 +718,24 @@ Logger.prototype.child = function (options, simple) {
  *
  * See <https://github.com/trentm/node-bunyan/issues/104>.
  */
-Logger.prototype.reopenFileStreams = function () {
-    var self = this;
-    self.streams.forEach(function (s) {
-        if (s.type === 'file') {
-            if (s.stream) {
-                // Not sure if typically would want this, or more immediate
-                // `s.stream.destroy()`.
-                s.stream.end();
-                s.stream.destroySoon();
-                delete s.stream;
-            }
-            s.stream = fs.createWriteStream(s.path,
-                {flags: 'a', encoding: 'utf8'});
-            s.stream.on('error', function (err) {
-                self.emit('error', err, s);
-            });
-        }
-    });
+Logger.prototype.reopenFileStreams = function() {
+  var self = this;
+  self.streams.forEach(function(s) {
+    if (s.type === 'file') {
+      if (s.stream) {
+        // Not sure if typically would want this, or more immediate
+        // `s.stream.destroy()`.
+        s.stream.end();
+        s.stream.destroySoon();
+        delete s.stream;
+      }
+      s.stream = fs.createWriteStream(s.path,
+        {flags: 'a', encoding: 'utf8'});
+      s.stream.on('error', function(err) {
+        self.emit('error', err, s);
+      });
+    }
+  });
 };
 
 
@@ -765,16 +776,16 @@ Logger.prototype.close = function () {
  *    log.level('info')     // can use 'info' et al aliases
  */
 Logger.prototype.level = function level(value) {
-    if (value === undefined) {
-        return this._level;
-    }
-    var newLevel = resolveLevel(value);
-    var len = this.streams.length;
-    for (var i = 0; i < len; i++) {
-        this.streams[i].level = newLevel;
-    }
-    this._level = newLevel;
-}
+  if (value === undefined) {
+    return this._level;
+  }
+  var newLevel = resolveLevel(value);
+  var len = this.streams.length;
+  for (var i = 0; i < len; i++) {
+    this.streams[i].level = newLevel;
+  }
+  this._level = newLevel;
+};
 
 
 /**
@@ -810,40 +821,40 @@ Logger.prototype.level = function level(value) {
  * @throws {Error} If there is no stream with the given name.
  */
 Logger.prototype.levels = function levels(name, value) {
-    if (name === undefined) {
-        assert.equal(value, undefined);
-        return this.streams.map(
-            function (s) { return s.level });
+  if (name === undefined) {
+    assert.equal(value, undefined);
+    return this.streams.map(
+      function(s) { return s.level; });
+  }
+  var stream;
+  if (typeof name === 'number') {
+    stream = this.streams[name];
+    if (stream === undefined) {
+      throw new Error('invalid stream index: ' + name);
     }
-    var stream;
-    if (typeof (name) === 'number') {
-        stream = this.streams[name];
-        if (stream === undefined) {
-            throw new Error('invalid stream index: ' + name);
-        }
-    } else {
-        var len = this.streams.length;
-        for (var i = 0; i < len; i++) {
-            var s = this.streams[i];
-            if (s.name === name) {
-                stream = s;
-                break;
-            }
-        }
-        if (!stream) {
-            throw new Error(format('no stream with name "%s"', name));
-        }
+  } else {
+    var len = this.streams.length;
+    for (var i = 0; i < len; i++) {
+      var s = this.streams[i];
+      if (s.name === name) {
+        stream = s;
+        break;
+      }
     }
-    if (value === undefined) {
-        return stream.level;
-    } else {
-        var newLevel = resolveLevel(value);
-        stream.level = newLevel;
-        if (newLevel < this._level) {
-            this._level = newLevel;
-        }
+    if (!stream) {
+      throw new Error(format('no stream with name "%s"', name));
     }
-}
+  }
+  if (value === undefined) {
+    return stream.level;
+  }
+  var newLevel = resolveLevel(value);
+  stream.level = newLevel;
+  if (newLevel < this._level) {
+    this._level = newLevel;
+  }
+
+};
 
 
 /**
@@ -855,32 +866,30 @@ Logger.prototype.levels = function levels(name, value) {
  * @param excludeFields (Object) Optional mapping of keys to `true` for
  *    keys to NOT apply a serializer.
  */
-Logger.prototype._applySerializers = function (fields, excludeFields) {
-    var self = this;
+Logger.prototype._applySerializers = function(fields, excludeFields) {
+  var self = this;
 
-    xxx('_applySerializers: excludeFields', excludeFields);
+  xxx('_applySerializers: excludeFields', excludeFields);
 
-    // Check each serializer against these (presuming number of serializers
-    // is typically less than number of fields).
-    Object.keys(this.serializers).forEach(function (name) {
-        if (fields[name] === undefined ||
-            (excludeFields && excludeFields[name]))
-        {
-            return;
-        }
-        xxx('_applySerializers; apply to "%s" key', name)
-        try {
-            fields[name] = self.serializers[name](fields[name]);
-        } catch (err) {
-            _warn(format('bunyan: ERROR: Exception thrown from the "%s" '
+  // Check each serializer against these (presuming number of serializers
+  // is typically less than number of fields).
+  Object.keys(this.serializers).forEach(function(name) {
+    if (fields[name] === undefined || (excludeFields && excludeFields[name])) {
+      return;
+    }
+    xxx('_applySerializers; apply to "%s" key', name);
+    try {
+      fields[name] = self.serializers[name](fields[name]);
+    } catch (err) {
+      _warn(format('bunyan: ERROR: Exception thrown from the "%s" '
                 + 'Bunyan serializer. This should never happen. This is a bug '
                 + 'in that serializer function.\n%s',
-                name, err.stack || err));
-            fields[name] = format('(Error in Bunyan log "%s" serializer '
+      name, err.stack || err));
+      fields[name] = format('(Error in Bunyan log "%s" serializer '
                 + 'broke field. See stderr for details.)', name);
-        }
-    });
-}
+    }
+  });
+};
 
 
 /**
@@ -890,42 +899,41 @@ Logger.prototype._applySerializers = function (fields, excludeFields) {
  * @param noemit {Boolean} Optional. Set to true to skip emission
  *      and just return the JSON string.
  */
-Logger.prototype._emit = function (rec, noemit) {
-    var i;
+Logger.prototype._emit = function(rec, noemit) {
+  var i;
 
-    // Lazily determine if this Logger has non-'raw' streams. If there are
-    // any, then we need to stringify the log record.
-    if (this.haveNonRawStreams === undefined) {
-        this.haveNonRawStreams = false;
-        for (i = 0; i < this.streams.length; i++) {
-            if (!this.streams[i].raw) {
-                this.haveNonRawStreams = true;
-                break;
-            }
-        }
-    }
-
-    // Stringify the object (creates a warning str on error).
-    var str;
-    if (noemit || this.haveNonRawStreams) {
-        str = fastAndSafeJsonStringify(rec) + '\n';
-    }
-
-    if (noemit)
-        return str;
-
-    var level = rec.level;
+  // Lazily determine if this Logger has non-'raw' streams. If there are
+  // any, then we need to stringify the log record.
+  if (this.haveNonRawStreams === undefined) {
+    this.haveNonRawStreams = false;
     for (i = 0; i < this.streams.length; i++) {
-        var s = this.streams[i];
-        if (s.level <= level) {
-            xxx('writing log rec "%s" to "%s" stream (%d <= %d): %j',
-                rec.msg, s.type, s.level, level, rec);
-            s.stream.write(s.raw ? rec : str);
-        }
-    };
+      if (!this.streams[i].raw) {
+        this.haveNonRawStreams = true;
+        break;
+      }
+    }
+  }
 
-    return str;
-}
+  // Stringify the object (creates a warning str on error).
+  var str;
+  if (noemit || this.haveNonRawStreams) {
+    str = fastAndSafeJsonStringify(rec) + '\n';
+  }
+
+  if (noemit) return str;
+
+  var level = rec.level;
+  for (i = 0; i < this.streams.length; i++) {
+    var s = this.streams[i];
+    if (s.level <= level) {
+      xxx('writing log rec "%s" to "%s" stream (%d <= %d): %j',
+        rec.msg, s.type, s.level, level, rec);
+      s.stream.write(s.raw ? rec : str);
+    }
+  }
+
+  return str;
+};
 
 
 /**
@@ -933,66 +941,65 @@ Logger.prototype._emit = function (rec, noemit) {
  * provided to the a log emitter.
  */
 function mkRecord(log, minLevel, args) {
-    var excludeFields, fields, msgArgs;
-    if (args[0] instanceof Error) {
-        // `log.<level>(err, ...)`
-        fields = {
-            // Use this Logger's err serializer, if defined.
-            err: (log.serializers && log.serializers.err
-                ? log.serializers.err(args[0])
-                : Logger.stdSerializers.err(args[0]))
-        };
-        excludeFields = {err: true};
-        if (args.length === 1) {
-            msgArgs = [fields.err.message];
-        } else {
-            msgArgs = args.slice(1);
-        }
-    } else if (typeof (args[0]) !== 'object' || Array.isArray(args[0])) {
-        // `log.<level>(msg, ...)`
-        fields = null;
-        msgArgs = args.slice();
-    } else if (Buffer.isBuffer(args[0])) {  // `log.<level>(buf, ...)`
-        // Almost certainly an error, show `inspect(buf)`. See bunyan
-        // issue #35.
-        fields = null;
-        msgArgs = args.slice();
-        msgArgs[0] = util.inspect(msgArgs[0]);
-    } else {  // `log.<level>(fields, msg, ...)`
-        fields = args[0];
-        if (fields && args.length === 1 && fields.err &&
-            fields.err instanceof Error)
-        {
-            msgArgs = [fields.err.message];
-        } else {
-            msgArgs = args.slice(1);
-        }
+  var excludeFields, fields, msgArgs;
+  if (args[0] instanceof Error) {
+    // `log.<level>(err, ...)`
+    fields = {
+      // Use this Logger's err serializer, if defined.
+      err: log.serializers && log.serializers.err
+        ? log.serializers.err(args[0])
+        : Logger.stdSerializers.err(args[0])
+    };
+    excludeFields = {err: true};
+    if (args.length === 1) {
+      msgArgs = [fields.err.message];
+    } else {
+      msgArgs = args.slice(1);
     }
+  } else if (typeof args[0] !== 'object' || Array.isArray(args[0])) {
+    // `log.<level>(msg, ...)`
+    fields = null;
+    msgArgs = args.slice();
+  } else if (Buffer.isBuffer(args[0])) { // `log.<level>(buf, ...)`
+    // Almost certainly an error, show `inspect(buf)`. See bunyan
+    // issue #35.
+    fields = null;
+    msgArgs = args.slice();
+    msgArgs[0] = util.inspect(msgArgs[0]);
+  } else { // `log.<level>(fields, msg, ...)`
+    fields = args[0];
+    if (fields && args.length === 1 && fields.err && fields.err instanceof Error) {
+      msgArgs = [fields.err.message];
+    } else {
+      msgArgs = args.slice(1);
+    }
+  }
 
-    // Build up the record object.
-    var rec = objCopy(log.fields);
-    var level = rec.level = minLevel;
-    var recFields = (fields ? objCopy(fields) : null);
-    if (recFields) {
-        if (log.serializers) {
-            log._applySerializers(recFields, excludeFields);
-        }
-        Object.keys(recFields).forEach(function (k) {
-            rec[k] = recFields[k];
-        });
+  // Build up the record object.
+  var rec = objCopy(log.fields);
+  // eslint-disable-next-line no-unused-vars
+  var level = rec.level = minLevel;
+  var recFields = fields ? objCopy(fields) : null;
+  if (recFields) {
+    if (log.serializers) {
+      log._applySerializers(recFields, excludeFields);
     }
-    rec.msg = format.apply(log, msgArgs);
-    if (!rec.time) {
-        rec.time = (new Date());
-    }
-    // Get call source info
-    if (log.src && !rec.src) {
-        rec.src = getCaller3Info()
-    }
-    rec.v = LOG_VERSION;
+    Object.keys(recFields).forEach(function(k) {
+      rec[k] = recFields[k];
+    });
+  }
+  rec.msg = format.apply(log, msgArgs);
+  if (!rec.time) {
+    rec.time = new Date();
+  }
+  // Get call source info
+  if (log.src && !rec.src) {
+    rec.src = getCaller3Info();
+  }
+  rec.v = LOG_VERSION;
 
-    return rec;
-};
+  return rec;
+}
 
 
 /**
@@ -1001,7 +1008,7 @@ function mkRecord(log, minLevel, args) {
  * record object and stringify it.
  */
 function mkProbeArgs(str, log, minLevel, msgArgs) {
-    return [ str || log._emit(mkRecord(log, minLevel, msgArgs), true) ];
+  return [str || log._emit(mkRecord(log, minLevel, msgArgs), true)];
 }
 
 
@@ -1010,45 +1017,46 @@ function mkProbeArgs(str, log, minLevel, msgArgs) {
  * creator of `log.info`, `log.error`, etc.
  */
 function mkLogEmitter(minLevel) {
-    return function () {
-        var log = this;
-        var str = null;
-        var rec = null;
+  return function() {
+    var log = this;
+    var str = null;
+    var rec = null;
 
-        if (!this._emit) {
-            /*
-             * Show this invalid Bunyan usage warning *once*.
-             *
-             * See <https://github.com/trentm/node-bunyan/issues/100> for
-             * an example of how this can happen.
-             */
-            var dedupKey = 'unbound';
-            if (!_haveWarned[dedupKey]) {
-                var caller = getCaller3Info();
-                _warn(format('bunyan usage error: %s:%s: attempt to log '
+    if (!this._emit) {
+
+      /*
+       * Show this invalid Bunyan usage warning *once*.
+       *
+       * See <https://github.com/trentm/node-bunyan/issues/100> for
+       * an example of how this can happen.
+       */
+      var dedupKey = 'unbound';
+      if (!_haveWarned[dedupKey]) {
+        var caller = getCaller3Info();
+        _warn(format('bunyan usage error: %s:%s: attempt to log '
                     + 'with an unbound log method: `this` is: %s',
-                    caller.file, caller.line, util.inspect(this)),
-                    dedupKey);
-            }
-            return;
-        } else if (arguments.length === 0) {   // `log.<level>()`
-            return (this._level <= minLevel);
-        }
-
-        var msgArgs = new Array(arguments.length);
-        for (var i = 0; i < msgArgs.length; ++i) {
-            msgArgs[i] = arguments[i];
-        }
-
-        if (this._level <= minLevel) {
-            rec = mkRecord(log, minLevel, msgArgs);
-            str = this._emit(rec);
-        }
-
-        if (probes) {
-            probes[minLevel].fire(mkProbeArgs, str, log, minLevel, msgArgs);
-        }
+        caller.file, caller.line, util.inspect(this)),
+        dedupKey);
+      }
+      return;
+    } else if (arguments.length === 0) { // `log.<level>()`
+      return this._level <= minLevel;
     }
+
+    var msgArgs = new Array(arguments.length);
+    for (var i = 0; i < msgArgs.length; ++i) {
+      msgArgs[i] = arguments[i];
+    }
+
+    if (this._level <= minLevel) {
+      rec = mkRecord(log, minLevel, msgArgs);
+      str = this._emit(rec);
+    }
+
+    if (probes) {
+      probes[minLevel].fire(mkProbeArgs, str, log, minLevel, msgArgs);
+    }
+  };
 }
 
 
@@ -1077,9 +1085,7 @@ Logger.prototype.warn = mkLogEmitter(WARN);
 Logger.prototype.error = mkLogEmitter(ERROR);
 Logger.prototype.fatal = mkLogEmitter(FATAL);
 
-
-
-//---- Standard serializers
+// ---- Standard serializers
 // A serializer is a function that serializes a JavaScript object to a
 // JSON representation for logging. There is a standard set of presumed
 // interesting objects in node.js-land.
@@ -1087,31 +1093,29 @@ Logger.prototype.fatal = mkLogEmitter(FATAL);
 Logger.stdSerializers = {};
 
 // Serialize an HTTP request.
-Logger.stdSerializers.req = function (req) {
-    if (!req || !req.connection)
-        return req;
-    return {
-        method: req.method,
-        url: req.url,
-        headers: req.headers,
-        remoteAddress: req.connection.remoteAddress,
-        remotePort: req.connection.remotePort
-    };
-    // Trailers: Skipping for speed. If you need trailers in your app, then
-    // make a custom serializer.
-    //if (Object.keys(trailers).length > 0) {
-    //  obj.trailers = req.trailers;
-    //}
+Logger.stdSerializers.req = function(req) {
+  if (!req || !req.connection) return req;
+  return {
+    method: req.method,
+    url: req.url,
+    headers: req.headers,
+    remoteAddress: req.connection.remoteAddress,
+    remotePort: req.connection.remotePort
+  };
+  // Trailers: Skipping for speed. If you need trailers in your app, then
+  // make a custom serializer.
+  // if (Object.keys(trailers).length > 0) {
+  //  obj.trailers = req.trailers;
+  // }
 };
 
 // Serialize an HTTP response.
-Logger.stdSerializers.res = function (res) {
-    if (!res || !res.statusCode)
-        return res;
-    return {
-        statusCode: res.statusCode,
-        header: res._header
-    }
+Logger.stdSerializers.res = function(res) {
+  if (!res || !res.statusCode) return res;
+  return {
+    statusCode: res.statusCode,
+    header: res._header
+  };
 };
 
 
@@ -1124,47 +1128,46 @@ Logger.stdSerializers.res = function (res) {
  * Based on `dumpException` in
  * https://github.com/davepacheco/node-extsprintf/blob/master/lib/extsprintf.js
  */
-function getFullErrorStack(ex)
-{
-    var ret = ex.stack || ex.toString();
-    if (ex.cause && typeof (ex.cause) === 'function') {
-        var cex = ex.cause();
-        if (cex) {
-            ret += '\nCaused by: ' + getFullErrorStack(cex);
-        }
+function getFullErrorStack(ex) {
+  var ret = ex.stack || ex.toString();
+  if (ex.cause && typeof ex.cause === 'function') {
+    var cex = ex.cause();
+    if (cex) {
+      ret += '\nCaused by: ' + getFullErrorStack(cex);
     }
-    return (ret);
+  }
+  return ret;
 }
 
 // Serialize an Error object
 // (Core error properties are enumerable in node 0.4, not in 0.6).
-var errSerializer = Logger.stdSerializers.err = function (err) {
-    if (!err || !err.stack)
-        return err;
-    var obj = {
-        message: err.message,
-        name: err.name,
-        stack: getFullErrorStack(err),
-        code: err.code,
-        signal: err.signal
-    }
-    return obj;
+// eslint-disable-next-line no-unused-vars
+var errSerializer = Logger.stdSerializers.err = function(err) {
+  if (!err || !err.stack) return err;
+  var obj = {
+    message: err.message,
+    name: err.name,
+    stack: getFullErrorStack(err),
+    code: err.code,
+    signal: err.signal
+  };
+  return obj;
 };
 
 
 // A JSON stringifier that handles cycles safely - tracks seen values in a Set.
 function safeCyclesSet() {
-    var seen = new Set();
-    return function (key, val) {
-        if (!val || typeof (val) !== 'object') {
-            return val;
-        }
-        if (seen.has(val)) {
-            return '[Circular]';
-        }
-        seen.add(val);
-        return val;
-    };
+  var seen = new Set();
+  return function(key, val) {
+    if (!val || typeof val !== 'object') {
+      return val;
+    }
+    if (seen.has(val)) {
+      return '[Circular]';
+    }
+    seen.add(val);
+    return val;
+  };
 }
 
 /**
@@ -1176,17 +1179,17 @@ function safeCyclesSet() {
  * when Set is not available.
  */
 function safeCyclesArray() {
-    var seen = [];
-    return function (key, val) {
-        if (!val || typeof (val) !== 'object') {
-            return val;
-        }
-        if (seen.indexOf(val) !== -1) {
-            return '[Circular]';
-        }
-        seen.push(val);
-        return val;
-    };
+  var seen = [];
+  return function(key, val) {
+    if (!val || typeof val !== 'object') {
+      return val;
+    }
+    if (seen.indexOf(val) !== -1) {
+      return '[Circular]';
+    }
+    seen.push(val);
+    return val;
+  };
 }
 
 /**
@@ -1197,7 +1200,7 @@ function safeCyclesArray() {
  * Choose the best safe cycle function from what is available - see
  * trentm/node-bunyan#445.
  */
-var safeCycles = typeof (Set) !== 'undefined' ? safeCyclesSet : safeCyclesArray;
+var safeCycles = typeof Set !== 'undefined' ? safeCyclesSet : safeCyclesArray;
 
 /**
  * A fast JSON.stringify that handles cycles and getter exceptions (when
@@ -1208,86 +1211,85 @@ var safeCycles = typeof (Set) !== 'undefined' ? safeCyclesSet : safeCyclesArray;
  * handlers that can deal with cycles and/or getter exceptions.
  */
 function fastAndSafeJsonStringify(rec) {
+  try {
+    return JSON.stringify(rec);
+  } catch (ex) {
     try {
-        return JSON.stringify(rec);
-    } catch (ex) {
-        try {
-            return JSON.stringify(rec, safeCycles());
-        } catch (e) {
-            if (safeJsonStringify) {
-                return safeJsonStringify(rec);
-            } else {
-                var dedupKey = e.stack.split(/\n/g, 3).join('\n');
-                _warn('bunyan: ERROR: Exception in '
+      return JSON.stringify(rec, safeCycles());
+    } catch (e) {
+      if (safeJsonStringify) {
+        return safeJsonStringify(rec);
+      }
+      var dedupKey = e.stack.split(/\n/g, 3).join('\n');
+      _warn('bunyan: ERROR: Exception in '
                     + '`JSON.stringify(rec)`. You can install the '
                     + '"safe-json-stringify" module to have Bunyan fallback '
                     + 'to safer stringification. Record:\n'
                     + _indent(format('%s\n%s', util.inspect(rec), e.stack)),
-                    dedupKey);
-                return format('(Exception in JSON.stringify(rec): %j. '
+      dedupKey);
+      return format('(Exception in JSON.stringify(rec): %j. '
                     + 'See stderr for details.)', e.message);
-            }
-        }
+
     }
+  }
 }
 
 
 var RotatingFileStream = null;
 if (mv) {
 
-RotatingFileStream = function RotatingFileStream(options) {
+  RotatingFileStream = function RotatingFileStream(options) {
     this.path = options.path;
 
-    this.count = (options.count == null ? 10 : options.count);
-    assert.equal(typeof (this.count), 'number',
-        format('rotating-file stream "count" is not a number: %j (%s) in %j',
-            this.count, typeof (this.count), this));
+    this.count = options.count == null ? 10 : options.count;
+    assert.equal(typeof this.count, 'number',
+      format('rotating-file stream "count" is not a number: %j (%s) in %j',
+        this.count, typeof this.count, this));
     assert.ok(this.count >= 0,
-        format('rotating-file stream "count" is not >= 0: %j in %j',
-            this.count, this));
+      format('rotating-file stream "count" is not >= 0: %j in %j',
+        this.count, this));
 
     // Parse `options.period`.
     if (options.period) {
-        // <number><scope> where scope is:
-        //    h   hours (at the start of the hour)
-        //    d   days (at the start of the day, i.e. just after midnight)
-        //    w   weeks (at the start of Sunday)
-        //    m   months (on the first of the month)
-        //    y   years (at the start of Jan 1st)
-        // with special values 'hourly' (1h), 'daily' (1d), "weekly" (1w),
-        // 'monthly' (1m) and 'yearly' (1y)
-        var period = {
-            'hourly': '1h',
-            'daily': '1d',
-            'weekly': '1w',
-            'monthly': '1m',
-            'yearly': '1y'
-        }[options.period] || options.period;
-        var m = /^([1-9][0-9]*)([hdwmy]|ms)$/.exec(period);
-        if (!m) {
-            throw new Error(format('invalid period: "%s"', options.period));
-        }
-        this.periodNum = Number(m[1]);
-        this.periodScope = m[2];
+      // <number><scope> where scope is:
+      //    h   hours (at the start of the hour)
+      //    d   days (at the start of the day, i.e. just after midnight)
+      //    w   weeks (at the start of Sunday)
+      //    m   months (on the first of the month)
+      //    y   years (at the start of Jan 1st)
+      // with special values 'hourly' (1h), 'daily' (1d), "weekly" (1w),
+      // 'monthly' (1m) and 'yearly' (1y)
+      var period = {
+        'hourly': '1h',
+        'daily': '1d',
+        'weekly': '1w',
+        'monthly': '1m',
+        'yearly': '1y'
+      }[options.period] || options.period;
+      var m = /^([1-9][0-9]*)([hdwmy]|ms)$/.exec(period);
+      if (!m) {
+        throw new Error(format('invalid period: "%s"', options.period));
+      }
+      this.periodNum = Number(m[1]);
+      this.periodScope = m[2];
     } else {
-        this.periodNum = 1;
-        this.periodScope = 'd';
+      this.periodNum = 1;
+      this.periodScope = 'd';
     }
 
     var lastModified = null;
     try {
-        var fileInfo = fs.statSync(this.path);
-        lastModified = fileInfo.mtime.getTime();
-    }
-    catch (err) {
-        // file doesn't exist
+      var fileInfo = fs.statSync(this.path);
+      lastModified = fileInfo.mtime.getTime();
+    } catch (err) {
+      // file doesn't exist
     }
     var rotateAfterOpen = false;
     if (lastModified) {
-        var lastRotTime = this._calcRotTime(0);
-        if (lastModified < lastRotTime) {
-            rotateAfterOpen = true;
-        }
+      var lastRotTime = this._calcRotTime(0);
+      if (lastModified < lastRotTime) {
+        rotateAfterOpen = true;
+      }
     }
 
     // TODO: template support for backup files
@@ -1307,62 +1309,62 @@ RotatingFileStream = function RotatingFileStream(options) {
     //                          filenames (illegal on Windows for one).
 
     this.stream = fs.createWriteStream(this.path,
-        {flags: 'a', encoding: 'utf8'});
+      {flags: 'a', encoding: 'utf8'});
 
     this.rotQueue = [];
     this.rotating = false;
     if (rotateAfterOpen) {
-        this._debug('rotateAfterOpen -> call rotate()');
-        this.rotate();
+      this._debug('rotateAfterOpen -> call rotate()');
+      this.rotate();
     } else {
-        this._setupNextRot();
+      this._setupNextRot();
     }
-}
+  };
 
-util.inherits(RotatingFileStream, EventEmitter);
+  util.inherits(RotatingFileStream, EventEmitter);
 
-RotatingFileStream.prototype._debug = function () {
+  RotatingFileStream.prototype._debug = function() {
     // Set this to `true` to add debug logging.
+    // eslint-disable-next-line no-constant-condition
     if (false) {
-        if (arguments.length === 0) {
-            return true;
-        }
-        var args = Array.prototype.slice.call(arguments);
-        args[0] = '[' + (new Date().toISOString()) + ', '
+      if (arguments.length === 0) {
+        return true;
+      }
+      var args = Array.prototype.slice.call(arguments);
+      args[0] = '[' + new Date().toISOString() + ', '
             + this.path + '] ' + args[0];
-        console.log.apply(this, args);
+      console.log.apply(this, args);
     } else {
-        return false;
+      return false;
     }
-};
+  };
 
-RotatingFileStream.prototype._setupNextRot = function () {
+  RotatingFileStream.prototype._setupNextRot = function() {
     this.rotAt = this._calcRotTime(1);
     this._setRotationTimer();
-}
+  };
 
-RotatingFileStream.prototype._setRotationTimer = function () {
+  RotatingFileStream.prototype._setRotationTimer = function() {
     var self = this;
     var delay = this.rotAt - Date.now();
     // Cap timeout to Node's max setTimeout, see
     // <https://github.com/joyent/node/issues/8656>.
     var TIMEOUT_MAX = 2147483647; // 2^31-1
     if (delay > TIMEOUT_MAX) {
-        delay = TIMEOUT_MAX;
+      delay = TIMEOUT_MAX;
     }
     this.timeout = setTimeout(
-        function () {
-            self._debug('_setRotationTimer timeout -> call rotate()');
-            self.rotate();
-        },
-        delay);
-    if (typeof (this.timeout.unref) === 'function') {
-        this.timeout.unref();
+      function() {
+        self._debug('_setRotationTimer timeout -> call rotate()');
+        self.rotate();
+      },
+      delay);
+    if (typeof this.timeout.unref === 'function') {
+      this.timeout.unref();
     }
-}
+  };
 
-RotatingFileStream.prototype._calcRotTime =
-function _calcRotTime(periodOffset) {
+  RotatingFileStream.prototype._calcRotTime = function _calcRotTime(periodOffset) {
     this._debug('_calcRotTime: %s%s', this.periodNum, this.periodScope);
     var d = new Date();
 
@@ -1370,187 +1372,186 @@ function _calcRotTime(periodOffset) {
     this._debug('    now utc: %s', d.toISOString());
     var rotAt;
     switch (this.periodScope) {
-    case 'ms':
-        // Hidden millisecond period for debugging.
+      case 'ms':
+      // Hidden millisecond period for debugging.
         if (this.rotAt) {
-            rotAt = this.rotAt + this.periodNum * periodOffset;
+          rotAt = this.rotAt + this.periodNum * periodOffset;
         } else {
-            rotAt = Date.now() + this.periodNum * periodOffset;
+          rotAt = Date.now() + this.periodNum * periodOffset;
         }
         break;
-    case 'h':
+      case 'h':
         if (this.rotAt) {
-            rotAt = this.rotAt + this.periodNum * 60 * 60 * 1000 * periodOffset;
+          rotAt = this.rotAt + this.periodNum * 60 * 60 * 1000 * periodOffset;
         } else {
-            // First time: top of the next hour.
-            rotAt = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(),
-                d.getUTCDate(), d.getUTCHours() + periodOffset);
+        // First time: top of the next hour.
+          rotAt = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(),
+            d.getUTCDate(), d.getUTCHours() + periodOffset);
         }
         break;
-    case 'd':
+      case 'd':
         if (this.rotAt) {
-            rotAt = this.rotAt + this.periodNum * 24 * 60 * 60 * 1000
+          rotAt = this.rotAt + this.periodNum * 24 * 60 * 60 * 1000
                 * periodOffset;
         } else {
-            // First time: start of tomorrow (i.e. at the coming midnight) UTC.
-            rotAt = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(),
-                d.getUTCDate() + periodOffset);
+        // First time: start of tomorrow (i.e. at the coming midnight) UTC.
+          rotAt = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(),
+            d.getUTCDate() + periodOffset);
         }
         break;
-    case 'w':
-        // Currently, always on Sunday morning at 00:00:00 (UTC).
+      case 'w':
+      // Currently, always on Sunday morning at 00:00:00 (UTC).
         if (this.rotAt) {
-            rotAt = this.rotAt + this.periodNum * 7 * 24 * 60 * 60 * 1000
+          rotAt = this.rotAt + this.periodNum * 7 * 24 * 60 * 60 * 1000
                 * periodOffset;
         } else {
-            // First time: this coming Sunday.
-            var dayOffset = (7 - d.getUTCDay());
-            if (periodOffset < 1) {
-                dayOffset = -d.getUTCDay();
-            }
-            if (periodOffset > 1 || periodOffset < -1) {
-                dayOffset += 7 * periodOffset;
-            }
-            rotAt = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(),
-                d.getUTCDate() + dayOffset);
+        // First time: this coming Sunday.
+          var dayOffset = 7 - d.getUTCDay();
+          if (periodOffset < 1) {
+            dayOffset = -d.getUTCDay();
+          }
+          if (periodOffset > 1 || periodOffset < -1) {
+            dayOffset += 7 * periodOffset;
+          }
+          rotAt = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(),
+            d.getUTCDate() + dayOffset);
         }
         break;
-    case 'm':
+      case 'm':
         if (this.rotAt) {
-            rotAt = Date.UTC(d.getUTCFullYear(),
-                d.getUTCMonth() + this.periodNum * periodOffset, 1);
+          rotAt = Date.UTC(d.getUTCFullYear(),
+            d.getUTCMonth() + this.periodNum * periodOffset, 1);
         } else {
-            // First time: the start of the next month.
-            rotAt = Date.UTC(d.getUTCFullYear(),
-                d.getUTCMonth() + periodOffset, 1);
+        // First time: the start of the next month.
+          rotAt = Date.UTC(d.getUTCFullYear(),
+            d.getUTCMonth() + periodOffset, 1);
         }
         break;
-    case 'y':
+      case 'y':
         if (this.rotAt) {
-            rotAt = Date.UTC(d.getUTCFullYear() + this.periodNum * periodOffset,
-                0, 1);
+          rotAt = Date.UTC(d.getUTCFullYear() + this.periodNum * periodOffset,
+            0, 1);
         } else {
-            // First time: the start of the next year.
-            rotAt = Date.UTC(d.getUTCFullYear() + periodOffset, 0, 1);
+        // First time: the start of the next year.
+          rotAt = Date.UTC(d.getUTCFullYear() + periodOffset, 0, 1);
         }
         break;
-    default:
+      default:
         assert.fail(format('invalid period scope: "%s"', this.periodScope));
     }
 
     if (this._debug()) {
-        this._debug('  **rotAt**: %s (utc: %s)', rotAt,
-            new Date(rotAt).toUTCString());
-        var now = Date.now();
-        this._debug('        now: %s (%sms == %smin == %sh to go)',
-            now,
-            rotAt - now,
-            (rotAt-now)/1000/60,
-            (rotAt-now)/1000/60/60);
+      this._debug('  **rotAt**: %s (utc: %s)', rotAt,
+        new Date(rotAt).toUTCString());
+      var now = Date.now();
+      this._debug('        now: %s (%sms == %smin == %sh to go)',
+        now,
+        rotAt - now,
+        (rotAt - now) / 1000 / 60,
+        (rotAt - now) / 1000 / 60 / 60);
     }
     return rotAt;
-};
+  };
 
-RotatingFileStream.prototype.rotate = function rotate() {
+  RotatingFileStream.prototype.rotate = function rotate() {
     // XXX What about shutdown?
     var self = this;
 
     // If rotation period is > ~25 days, we have to break into multiple
     // setTimeout's. See <https://github.com/joyent/node/issues/8656>.
     if (self.rotAt && self.rotAt > Date.now()) {
-        return self._setRotationTimer();
+      return self._setRotationTimer();
     }
 
     this._debug('rotate');
     if (self.rotating) {
-        throw new TypeError('cannot start a rotation when already rotating');
+      throw new TypeError('cannot start a rotation when already rotating');
     }
     self.rotating = true;
 
-    self.stream.end();  // XXX can do moves sync after this? test at high rate
+    self.stream.end(); // XXX can do moves sync after this? test at high rate
 
     function del() {
-        var toDel = self.path + '.' + String(n - 1);
-        if (n === 0) {
-            toDel = self.path;
-        }
-        n -= 1;
-        self._debug('  rm %s', toDel);
-        fs.unlink(toDel, function (delErr) {
-            //XXX handle err other than not exists
-            moves();
-        });
+      var toDel = self.path + '.' + String(n - 1);
+      if (n === 0) {
+        toDel = self.path;
+      }
+      n -= 1;
+      self._debug('  rm %s', toDel);
+      fs.unlink(toDel, function(delErr) {
+        // XXX handle err other than not exists
+        moves();
+      });
     }
 
     function moves() {
-        if (self.count === 0 || n < 0) {
-            return finish();
-        }
-        var before = self.path;
-        var after = self.path + '.' + String(n);
-        if (n > 0) {
-            before += '.' + String(n - 1);
-        }
-        n -= 1;
-        fs.exists(before, function (exists) {
-            if (!exists) {
-                moves();
+      if (self.count === 0 || n < 0) {
+        return finish();
+      }
+      var before = self.path;
+      var after = self.path + '.' + String(n);
+      if (n > 0) {
+        before += '.' + String(n - 1);
+      }
+      n -= 1;
+      // eslint-disable-next-line node/no-deprecated-api
+      fs.exists(before, function(exists) {
+        if (!exists) {
+          moves();
+        } else {
+          self._debug('  mv %s %s', before, after);
+          mv(before, after, function(mvErr) {
+            if (mvErr) {
+              self.emit('error', mvErr);
+              finish(); // XXX finish here?
             } else {
-                self._debug('  mv %s %s', before, after);
-                mv(before, after, function (mvErr) {
-                    if (mvErr) {
-                        self.emit('error', mvErr);
-                        finish(); // XXX finish here?
-                    } else {
-                        moves();
-                    }
-                });
+              moves();
             }
-        })
+          });
+        }
+      });
     }
 
     function finish() {
-        self._debug('  open %s', self.path);
-        self.stream = fs.createWriteStream(self.path,
-            {flags: 'a', encoding: 'utf8'});
-        var q = self.rotQueue, len = q.length;
-        for (var i = 0; i < len; i++) {
-            self.stream.write(q[i]);
-        }
-        self.rotQueue = [];
-        self.rotating = false;
-        self.emit('drain');
-        self._setupNextRot();
+      self._debug('  open %s', self.path);
+      self.stream = fs.createWriteStream(self.path,
+        {flags: 'a', encoding: 'utf8'});
+      var q = self.rotQueue, len = q.length;
+      for (var i = 0; i < len; i++) {
+        self.stream.write(q[i]);
+      }
+      self.rotQueue = [];
+      self.rotating = false;
+      self.emit('drain');
+      self._setupNextRot();
     }
 
     var n = this.count;
     del();
-};
+  };
 
-RotatingFileStream.prototype.write = function write(s) {
+  RotatingFileStream.prototype.write = function write(s) {
     if (this.rotating) {
-        this.rotQueue.push(s);
-        return false;
-    } else {
-        return this.stream.write(s);
+      this.rotQueue.push(s);
+      return false;
     }
-};
+    return this.stream.write(s);
 
-RotatingFileStream.prototype.end = function end(s) {
+  };
+
+  RotatingFileStream.prototype.end = function end(s) {
     this.stream.end();
-};
+  };
 
-RotatingFileStream.prototype.destroy = function destroy(s) {
+  RotatingFileStream.prototype.destroy = function destroy(s) {
     this.stream.destroy();
-};
+  };
 
-RotatingFileStream.prototype.destroySoon = function destroySoon(s) {
+  RotatingFileStream.prototype.destroySoon = function destroySoon(s) {
     this.stream.destroySoon();
-};
+  };
 
 } /* if (mv) */
-
-
 
 /**
  * RingBuffer is a Writable Stream that just stores the last N records in
@@ -1561,43 +1562,40 @@ RotatingFileStream.prototype.destroySoon = function destroySoon(s) {
  *    - limit: number of records to keep in memory
  */
 function RingBuffer(options) {
-    this.limit = options && options.limit ? options.limit : 100;
-    this.writable = true;
-    this.records = [];
-    EventEmitter.call(this);
+  this.limit = options && options.limit ? options.limit : 100;
+  this.writable = true;
+  this.records = [];
+  EventEmitter.call(this);
 }
 
 util.inherits(RingBuffer, EventEmitter);
 
-RingBuffer.prototype.write = function (record) {
-    if (!this.writable)
-        throw (new Error('RingBuffer has been ended already'));
+RingBuffer.prototype.write = function(record) {
+  if (!this.writable) throw new Error('RingBuffer has been ended already');
 
-    this.records.push(record);
+  this.records.push(record);
 
-    if (this.records.length > this.limit)
-        this.records.shift();
+  if (this.records.length > this.limit) this.records.shift();
 
-    return (true);
+  return true;
 };
 
-RingBuffer.prototype.end = function () {
-    if (arguments.length > 0)
-        this.write.apply(this, Array.prototype.slice.call(arguments));
-    this.writable = false;
+RingBuffer.prototype.end = function() {
+  if (arguments.length > 0) this.write.apply(this, Array.prototype.slice.call(arguments));
+  this.writable = false;
 };
 
-RingBuffer.prototype.destroy = function () {
-    this.writable = false;
-    this.emit('close');
+RingBuffer.prototype.destroy = function() {
+  this.writable = false;
+  this.emit('close');
 };
 
-RingBuffer.prototype.destroySoon = function () {
-    this.destroy();
+RingBuffer.prototype.destroySoon = function() {
+  this.destroy();
 };
 
 
-//---- Exports
+// ---- Exports
 
 module.exports = Logger;
 
@@ -1615,7 +1613,7 @@ module.exports.VERSION = VERSION;
 module.exports.LOG_VERSION = LOG_VERSION;
 
 module.exports.createLogger = function createLogger(options) {
-    return new Logger(options);
+  return new Logger(options);
 };
 
 module.exports.RingBuffer = RingBuffer;

--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -21,22 +21,21 @@
  * vim: expandtab:ts=4:sw=4
  */
 
-var VERSION = '1.8.10';
+const VERSION = '1.8.10';
 
 /*
  * Bunyan log format version. This becomes the 'v' field on all log records.
  * This will be incremented if there is any backward incompatible change to
  * the log record format. Details will be in 'CHANGES.md' (the change log).
  */
-var LOG_VERSION = 0;
+const LOG_VERSION = 0;
 
 
-var xxx = function xxx(s) { // internal dev/debug logging
-  var args = ['XXX: ' + s].concat(
-    Array.prototype.slice.call(arguments, 1));
+let xxx = (s) => { // internal dev/debug logging
+  const args = ['XXX: ' + s].concat(Array.prototype.slice.call(arguments, 1));
   console.error.apply(this, args);
 };
-xxx = function xxx() {}; // comment out to turn on debug logging
+xxx = () => {}; // comment out to turn on debug logging
 
 
 /*
@@ -59,7 +58,7 @@ xxx = function xxx() {}; // comment out to turn on debug logging
  *        from browserify with `require('frobshizzle')`.
  * - Other? Please open issues if things are broken.
  */
-var runtimeEnv;
+let runtimeEnv;
 if (typeof process !== 'undefined' && process.versions) {
   if (process.versions.nw) {
     runtimeEnv = 'nw';
@@ -75,7 +74,7 @@ if (!runtimeEnv) {
 }
 
 
-var os, fs, dtrace;
+let os, fs, dtrace;
 if (runtimeEnv === 'browser') {
   os = {
     hostname: function() {
@@ -94,12 +93,12 @@ if (runtimeEnv === 'browser') {
     dtrace = null;
   }
 }
-var util = require('util');
-var assert = require('assert');
-var EventEmitter = require('events').EventEmitter;
-var stream = require('stream');
+const util = require('util');
+const assert = require('assert');
+const EventEmitter = require('events').EventEmitter;
+const stream = require('stream');
 
-var safeJsonStringify, mv, sourceMapSupport;
+let safeJsonStringify, mv, sourceMapSupport;
 try {
   safeJsonStringify = require('safe-json-stringify');
 } catch (e) {
@@ -136,78 +135,69 @@ function objCopy(obj) {
   } else if (Array.isArray(obj)) {
     return obj.slice();
   } else if (typeof obj === 'object') {
-    var copy = {};
-    Object.keys(obj).forEach(function(k) {
-      copy[k] = obj[k];
-    });
+    let copy = {};
+    Object.assign(copy, obj);
     return copy;
   }
   return obj;
 }
 
-var format = util.format;
-if (!format) {
-  // If node < 0.6, then use its `util.format`:
-  // <https://github.com/joyent/node/blob/master/lib/util.js#L22>:
-  var inspect = util.inspect;
-  var formatRegExp = /%[sdj%]/g;
-  format = function format(f) {
-    if (typeof f !== 'string') {
-      var objects = [];
-      for (var i = 0; i < arguments.length; i++) {
-        objects.push(inspect(arguments[i]));
-      }
-      return objects.join(' ');
-    }
 
-    var i = 1;
-    var args = arguments;
-    var len = args.length;
-    var str = String(f).replace(formatRegExp, function(x) {
-      if (i >= len) return x;
-      switch (x) {
-        case '%s': return String(args[i++]);
-        case '%d': return Number(args[i++]);
-        case '%j': return fastAndSafeJsonStringify(args[i++]);
-        case '%%': return '%';
-        default:
-          return x;
-      }
-    });
-    for (var x = args[i]; i < len; x = args[++i]) {
-      if (x === null || typeof x !== 'object') {
-        str += ' ' + x;
-      } else {
-        str += ' ' + inspect(x);
-      }
+const inspect = util.inspect;
+const formatRegExp = /%[sdj%]/g;
+const format = function format(f) {
+  if (typeof f !== 'string') {
+    let objects = [];
+    for (const argument of arguments) {
+      objects.push(inspect(argument));
     }
-    return str;
-  };
-}
+    return objects.join(' ');
+  }
 
+  let i = 1;
+  const args = arguments;
+  const len = args.length;
+  let str = String(f).replace(formatRegExp, (x) => {
+    if (i >= len) return x;
+    switch (x) {
+      case '%s': return String(args[i++]);
+      case '%d': return Number(args[i++]);
+      case '%j': return fastAndSafeJsonStringify(args[i++]);
+      case '%%': return '%';
+      default:
+        return x;
+    }
+  });
+  for (let x = args[i]; i < len; x = args[++i]) {
+    if (x === null || typeof x !== 'object') {
+      str += ' ' + x;
+    } else {
+      str += ' ' + inspect(x);
+    }
+  }
+  return str;
+};
 
 /**
  * Gather some caller info 3 stack levels up.
  * See <http://code.google.com/p/v8/wiki/JavaScriptStackTraceApi>.
  */
 function getCaller3Info() {
-  if (this === undefined) {
-    // Cannot access caller info in 'strict' mode.
-    return;
-  }
-  var obj = {};
-  var saveLimit = Error.stackTraceLimit;
-  var savePrepare = Error.prepareStackTrace;
+  // Cannot access caller info in 'strict' mode.
+  if (this === undefined) return;
+
+  let obj = {};
+  const saveLimit = Error.stackTraceLimit;
+  const savePrepare = Error.prepareStackTrace;
   Error.stackTraceLimit = 3;
 
-  Error.prepareStackTrace = function(_, stack) {
-    var caller = stack[2];
-    if (sourceMapSupport) {
-      caller = sourceMapSupport.wrapCallSite(caller);
-    }
+  Error.prepareStackTrace = (_, stack) => {
+    let caller = stack[2];
+    if (sourceMapSupport) caller = sourceMapSupport.wrapCallSite(caller);
+
     obj.file = caller.getFileName();
     obj.line = caller.getLineNumber();
-    var func = caller.getFunctionName();
+    const func = caller.getFunctionName();
     if (func) obj.func = func;
   };
   Error.captureStackTrace(this, getCaller3Info);
@@ -222,7 +212,7 @@ function getCaller3Info() {
 
 function _indent(s, indent) {
   if (!indent) indent = '    ';
-  var lines = s.split(/\r?\n/g);
+  const lines = s.split(/\r?\n/g);
   return indent + lines.join('\n' + indent);
 }
 
@@ -237,9 +227,7 @@ function _indent(s, indent) {
 function _warn(msg, dedupKey) {
   assert.ok(msg);
   if (dedupKey) {
-    if (_warned[dedupKey]) {
-      return;
-    }
+    if (_warned[dedupKey]) return;
     _warned[dedupKey] = true;
   }
   process.stderr.write(msg + '\n');
@@ -247,11 +235,11 @@ function _warn(msg, dedupKey) {
 function _haveWarned(dedupKey) {
   return _warned[dedupKey];
 }
-var _warned = {};
+let _warned = {};
 
 
 function ConsoleRawStream() {}
-ConsoleRawStream.prototype.write = function(rec) {
+ConsoleRawStream.prototype.write = (rec) => {
   if (rec.level < INFO) {
     console.log(rec);
   } else if (rec.level < WARN) {
@@ -266,14 +254,14 @@ ConsoleRawStream.prototype.write = function(rec) {
 
 // ---- Levels
 
-var TRACE = 10;
-var DEBUG = 20;
-var INFO = 30;
-var WARN = 40;
-var ERROR = 50;
-var FATAL = 60;
+const TRACE = 10,
+  DEBUG = 20,
+  INFO = 30,
+  WARN = 40,
+  ERROR = 50,
+  FATAL = 60;
 
-var levelFromName = {
+const levelFromName = {
   'trace': TRACE,
   'debug': DEBUG,
   'info': INFO,
@@ -281,15 +269,13 @@ var levelFromName = {
   'error': ERROR,
   'fatal': FATAL
 };
-var nameFromLevel = {};
-Object.keys(levelFromName).forEach(function(name) {
-  nameFromLevel[levelFromName[name]] = name;
-});
+let nameFromLevel = {};
+Object.assign(nameFromLevel, levelFromName);
 
 // Dtrace probes.
 // eslint-disable-next-line no-undef-init
-var dtp = undefined;
-var probes = dtrace && {};
+let dtp;
+const probes = dtrace && {};
 
 /**
  * Resolve a level number, name (upper or lowercase) to a level number value.
@@ -299,19 +285,17 @@ var probes = dtrace && {};
  * @api public
  */
 function resolveLevel(nameOrNum) {
-  var level;
-  var type = typeof nameOrNum;
+  let level;
+  const type = typeof nameOrNum;
   if (type === 'string') {
     level = levelFromName[nameOrNum.toLowerCase()];
     if (!level) {
       throw new Error(format('unknown level name: "%s"', nameOrNum));
     }
   } else if (type !== 'number') {
-    throw new TypeError(format('cannot resolve level: invalid arg (%s):',
-      type, nameOrNum));
+    throw new TypeError(format('cannot resolve level: invalid arg (%s):', type, nameOrNum));
   } else if (nameOrNum < 0 || Math.floor(nameOrNum) !== nameOrNum) {
-    throw new TypeError(format('level is not a positive integer: %s',
-      nameOrNum));
+    throw new TypeError(format('level is not a positive integer: %s', nameOrNum));
   } else {
     level = nameOrNum;
   }
@@ -320,9 +304,7 @@ function resolveLevel(nameOrNum) {
 
 
 function isWritable(obj) {
-  if (obj instanceof stream.Writable) {
-    return true;
-  }
+  if (obj instanceof stream.Writable)  return true;
   return typeof obj.write === 'function';
 }
 
@@ -366,32 +348,22 @@ function isWritable(obj) {
  */
 function Logger(options, _childOptions, _childSimple) {
   xxx('Logger start:', options);
-  if (!(this instanceof Logger)) {
-    return new Logger(options, _childOptions);
-  }
+  if (!(this instanceof Logger)) return new Logger(options, _childOptions);
 
   // Input arg validation.
-  var parent;
+  let parent;
   if (_childOptions !== undefined) {
     parent = options;
     options = _childOptions;
     if (!(parent instanceof Logger)) {
-      throw new TypeError(
-        'invalid Logger creation: do not pass a second arg');
+      throw new TypeError('invalid Logger creation: do not pass a second arg');
     }
   }
-  if (!options) {
-    throw new TypeError('options (object) is required');
-  }
+  if (!options) throw new TypeError('options (object) is required');
   if (!parent) {
-    if (!options.name) {
-      throw new TypeError('options.name (string) is required');
-    }
+    if (!options.name) throw new TypeError('options.name (string) is required');
   } else {
-    if (options.name) {
-      throw new TypeError(
-        'invalid options.name: child cannot set logger name');
-    }
+    if (options.name)  throw new TypeError('invalid options.name: child cannot set logger name');
   }
   if (options.stream && options.streams) {
     throw new TypeError('cannot mix "streams" and "stream" options');
@@ -415,36 +387,26 @@ function Logger(options, _childOptions, _childSimple) {
     this.streams = parent.streams;
     this.serializers = parent.serializers;
     this.src = parent.src;
-    var fields = this.fields = {};
-    var parentFieldNames = Object.keys(parent.fields);
-    for (var i = 0; i < parentFieldNames.length; i++) {
-      var name = parentFieldNames[i];
-      fields[name] = parent.fields[name];
-    }
-    var names = Object.keys(options);
-    for (var i = 0; i < names.length; i++) {
-      var name = names[i];
-      fields[name] = options[name];
-    }
+    let fields = this.fields = {};
+    Object.assign(fields, parent.fields, options);
+
     return;
   }
 
   // Start values.
-  var self = this;
+  const self = this;
   if (parent) {
     this._level = parent._level;
     this.streams = [];
-    for (var i = 0; i < parent.streams.length; i++) {
-      var s = objCopy(parent.streams[i]);
+    for (const i of parent.streams) {
+      let s = objCopy(i);
       s.closeOnExit = false; // Don't own parent stream.
       this.streams.push(s);
     }
     this.serializers = objCopy(parent.serializers);
     this.src = parent.src;
     this.fields = objCopy(parent.fields);
-    if (options.level) {
-      this.level(options.level);
-    }
+    if (options.level) this.level(options.level);
   } else {
     this._level = Number.POSITIVE_INFINITY;
     this.streams = [];
@@ -456,8 +418,8 @@ function Logger(options, _childOptions, _childSimple) {
   if (!dtp && dtrace) {
     dtp = dtrace.createDTraceProvider('bunyan');
 
-    for (var level in levelFromName) {
-      var probe;
+    for (const level in levelFromName) {
+      let probe;
 
       probes[levelFromName[level]] = probe = dtp.addProbe('log-' + level, 'char *');
 
@@ -478,7 +440,7 @@ function Logger(options, _childOptions, _childSimple) {
       level: options.level
     });
   } else if (options.streams) {
-    options.streams.forEach(function(s) {
+    options.streams.forEach((s) => {
       self.addStream(s, options.level);
     });
   } else if (parent && options.level) {
@@ -487,12 +449,12 @@ function Logger(options, _childOptions, _childSimple) {
     if (runtimeEnv === 'browser') {
 
       /*
-             * In the browser we'll be emitting to console.log by default.
-             * Any console.log worth its salt these days can nicely render
-             * and introspect objects (e.g. the Firefox and Chrome console)
-             * so let's emit the raw log record. Are there browsers for which
-             * that breaks things?
-             */
+       * In the browser we'll be emitting to console.log by default.
+       * Any console.log worth its salt these days can nicely render
+       * and introspect objects (e.g. the Firefox and Chrome console)
+       * so let's emit the raw log record. Are there browsers for which
+       * that breaks things?
+       */
       self.addStream({
         type: 'raw',
         stream: new ConsoleRawStream(),
@@ -508,12 +470,9 @@ function Logger(options, _childOptions, _childSimple) {
       });
     }
   }
-  if (options.serializers) {
-    self.addSerializers(options.serializers);
-  }
-  if (options.src) {
-    this.src = true;
-  }
+  if (options.serializers) self.addSerializers(options.serializers);
+  if (options.src) this.src = true;
+
   xxx('Logger: ', self);
 
   // Fields.
@@ -521,24 +480,20 @@ function Logger(options, _childOptions, _childSimple) {
   // removed in this constructor). To allow storing raw log records
   // (unrendered), `this.fields` must never be mutated. Create a copy for
   // any changes.
-  var fields = objCopy(options);
+  const fields = objCopy(options);
   delete fields.stream;
   delete fields.level;
   delete fields.streams;
   delete fields.serializers;
   delete fields.src;
-  if (this.serializers) {
-    this._applySerializers(fields);
-  }
+  if (this.serializers) this._applySerializers(fields);
+
   if (!fields.hostname && !self.fields.hostname) {
     fields.hostname = os.hostname();
   }
-  if (!fields.pid) {
-    fields.pid = process.pid;
-  }
-  Object.keys(fields).forEach(function(k) {
-    self.fields[k] = fields[k];
-  });
+  if (!fields.pid) fields.pid = process.pid;
+
+  Object.assign(self.fields, fields);
 }
 
 util.inherits(Logger, EventEmitter);
@@ -562,7 +517,7 @@ util.inherits(Logger, EventEmitter);
  *      `stream.level` is not set. If neither is given, this defaults to INFO.
  */
 Logger.prototype.addStream = function addStream(s, defaultLevel) {
-  var self = this;
+  const self = this;
   if (defaultLevel === null || defaultLevel === undefined) {
     defaultLevel = INFO;
   }
@@ -584,59 +539,42 @@ Logger.prototype.addStream = function addStream(s, defaultLevel) {
   } else {
     s.level = resolveLevel(defaultLevel);
   }
-  if (s.level < self._level) {
-    self._level = s.level;
-  }
+  if (s.level < self._level) self._level = s.level;
 
   switch (s.type) {
     case 'stream':
-      assert.ok(isWritable(s.stream),
-        '"stream" stream is not writable: ' + util.inspect(s.stream));
+      assert.ok(isWritable(s.stream), '"stream" stream is not writable: ' + util.inspect(s.stream));
 
-      if (!s.closeOnExit) {
-        s.closeOnExit = false;
-      }
+      if (!s.closeOnExit) s.closeOnExit = false;
       break;
     case 'file':
-      if (s.reemitErrorEvents === undefined) {
-        s.reemitErrorEvents = true;
-      }
+      if (s.reemitErrorEvents === undefined) s.reemitErrorEvents = true;
+
       if (!s.stream) {
-        s.stream = fs.createWriteStream(s.path,
-          {flags: 'a', encoding: 'utf8'});
-        if (!s.closeOnExit) {
-          s.closeOnExit = true;
-        }
+        s.stream = fs.createWriteStream(s.path, {flags: 'a', encoding: 'utf8'});
+        if (!s.closeOnExit) s.closeOnExit = true;
       } else {
-        if (!s.closeOnExit) {
-          s.closeOnExit = false;
-        }
+        if (!s.closeOnExit) s.closeOnExit = false;
       }
       break;
     case 'rotating-file':
-      assert.ok(!s.stream,
-        '"rotating-file" stream should not give a "stream"');
+      assert.ok(!s.stream, '"rotating-file" stream should not give a "stream"');
       assert.ok(s.path);
-      assert.ok(mv, '"rotating-file" stream type is not supported: '
-                      + 'missing "mv" module');
+      assert.ok(mv, '"rotating-file" stream type is not supported: missing "mv" module');
       s.stream = new RotatingFileStream(s);
-      if (!s.closeOnExit) {
-        s.closeOnExit = true;
-      }
+      if (!s.closeOnExit) s.closeOnExit = true;
       break;
     case 'raw':
-      if (!s.closeOnExit) {
-        s.closeOnExit = false;
-      }
+      if (!s.closeOnExit) s.closeOnExit = false;
       break;
     default:
-      throw new TypeError('unknown stream type "' + s.type + '"');
+      throw new TypeError(`unknown stream type "${s.type}"`);
   }
 
   if (s.reemitErrorEvents && typeof s.stream.on === 'function') {
     // TODO: When we have `<logger>.close()`, it should remove event
     //      listeners to not leak Logger instances.
-    s.stream.on('error', function onStreamError(err) {
+    s.stream.on('error', (err) => {
       self.emit('error', err, s);
     });
   }
@@ -653,17 +591,16 @@ Logger.prototype.addStream = function addStream(s, defaultLevel) {
  *    to serializing functions. See README.md for details.
  */
 Logger.prototype.addSerializers = function addSerializers(serializers) {
-  var self = this;
+  const self = this;
 
-  if (!self.serializers) {
-    self.serializers = {};
-  }
-  Object.keys(serializers).forEach(function(field) {
-    var serializer = serializers[field];
+  if (!self.serializers) self.serializers = {};
+
+  Object.keys(serializers).forEach((field) => {
+    const serializer = serializers[field];
     if (typeof serializer !== 'function') {
-      throw new TypeError(format(
-        'invalid serializer for "%s" field: must be a function',
-        field));
+      throw new TypeError(
+        format('invalid serializer for "%s" field: must be a function', field)
+      );
     } else {
       self.serializers[field] = serializer;
     }
@@ -719,8 +656,8 @@ Logger.prototype.child = function(options, simple) {
  * See <https://github.com/trentm/node-bunyan/issues/104>.
  */
 Logger.prototype.reopenFileStreams = function() {
-  var self = this;
-  self.streams.forEach(function(s) {
+  const self = this;
+  self.streams.forEach((s) => {
     if (s.type === 'file') {
       if (s.stream) {
         // Not sure if typically would want this, or more immediate
@@ -729,9 +666,8 @@ Logger.prototype.reopenFileStreams = function() {
         s.stream.destroySoon();
         delete s.stream;
       }
-      s.stream = fs.createWriteStream(s.path,
-        {flags: 'a', encoding: 'utf8'});
-      s.stream.on('error', function(err) {
+      s.stream = fs.createWriteStream(s.path, { flags: 'a', encoding: 'utf8' });
+      s.stream.on('error', (err) => {
         self.emit('error', err, s);
       });
     }
@@ -776,13 +712,11 @@ Logger.prototype.close = function () {
  *    log.level('info')     // can use 'info' et al aliases
  */
 Logger.prototype.level = function level(value) {
-  if (value === undefined) {
-    return this._level;
-  }
-  var newLevel = resolveLevel(value);
-  var len = this.streams.length;
-  for (var i = 0; i < len; i++) {
-    this.streams[i].level = newLevel;
+  if (value === undefined) return this._level;
+
+  const newLevel = resolveLevel(value);
+  for (const i of this.streams) {
+    i.level = newLevel;
   }
   this._level = newLevel;
 };
@@ -823,36 +757,26 @@ Logger.prototype.level = function level(value) {
 Logger.prototype.levels = function levels(name, value) {
   if (name === undefined) {
     assert.equal(value, undefined);
-    return this.streams.map(
-      function(s) { return s.level; });
+    return this.streams.map((s) => s.level);
   }
-  var stream;
+  let stream;
   if (typeof name === 'number') {
     stream = this.streams[name];
-    if (stream === undefined) {
-      throw new Error('invalid stream index: ' + name);
-    }
+    if (stream === undefined) throw new Error('invalid stream index: ' + name);
   } else {
-    var len = this.streams.length;
-    for (var i = 0; i < len; i++) {
-      var s = this.streams[i];
+    for (const s of this.streams) {
       if (s.name === name) {
         stream = s;
         break;
       }
     }
-    if (!stream) {
-      throw new Error(format('no stream with name "%s"', name));
-    }
+    if (!stream) throw new Error(format('no stream with name "%s"', name));
   }
-  if (value === undefined) {
-    return stream.level;
-  }
-  var newLevel = resolveLevel(value);
+  if (value === undefined) return stream.level;
+
+  const newLevel = resolveLevel(value);
   stream.level = newLevel;
-  if (newLevel < this._level) {
-    this._level = newLevel;
-  }
+  if (newLevel < this._level) this._level = newLevel;
 
 };
 
@@ -867,26 +791,29 @@ Logger.prototype.levels = function levels(name, value) {
  *    keys to NOT apply a serializer.
  */
 Logger.prototype._applySerializers = function(fields, excludeFields) {
-  var self = this;
+  const self = this;
 
   xxx('_applySerializers: excludeFields', excludeFields);
 
   // Check each serializer against these (presuming number of serializers
   // is typically less than number of fields).
   Object.keys(this.serializers).forEach(function(name) {
-    if (fields[name] === undefined || (excludeFields && excludeFields[name])) {
-      return;
-    }
+    if (fields[name] === undefined || (excludeFields && excludeFields[name])) return;
+
     xxx('_applySerializers; apply to "%s" key', name);
     try {
       fields[name] = self.serializers[name](fields[name]);
     } catch (err) {
-      _warn(format('bunyan: ERROR: Exception thrown from the "%s" '
-                + 'Bunyan serializer. This should never happen. This is a bug '
-                + 'in that serializer function.\n%s',
-      name, err.stack || err));
-      fields[name] = format('(Error in Bunyan log "%s" serializer '
-                + 'broke field. See stderr for details.)', name);
+      _warn(
+        format(
+          'bunyan: ERROR: Exception thrown from the "%s" '
+          + 'Bunyan serializer. This should never happen. This is a bug '
+          + 'in that serializer function.\n%s',
+          name,
+          err.stack || err
+        )
+      );
+      fields[name] = format('(Error in Bunyan log "%s" serializer broke field. See stderr for details.)', name);
     }
   });
 };
@@ -900,14 +827,12 @@ Logger.prototype._applySerializers = function(fields, excludeFields) {
  *      and just return the JSON string.
  */
 Logger.prototype._emit = function(rec, noemit) {
-  var i;
-
   // Lazily determine if this Logger has non-'raw' streams. If there are
   // any, then we need to stringify the log record.
   if (this.haveNonRawStreams === undefined) {
     this.haveNonRawStreams = false;
-    for (i = 0; i < this.streams.length; i++) {
-      if (!this.streams[i].raw) {
+    for (const s of this.streams) {
+      if (!s.raw) {
         this.haveNonRawStreams = true;
         break;
       }
@@ -915,23 +840,20 @@ Logger.prototype._emit = function(rec, noemit) {
   }
 
   // Stringify the object (creates a warning str on error).
-  var str;
+  let str;
   if (noemit || this.haveNonRawStreams) {
     str = fastAndSafeJsonStringify(rec) + '\n';
   }
 
   if (noemit) return str;
 
-  var level = rec.level;
-  for (i = 0; i < this.streams.length; i++) {
-    var s = this.streams[i];
+  const level = rec.level;
+  for (const s of this.streams) {
     if (s.level <= level) {
-      xxx('writing log rec "%s" to "%s" stream (%d <= %d): %j',
-        rec.msg, s.type, s.level, level, rec);
+      xxx('writing log rec "%s" to "%s" stream (%d <= %d): %j', rec.msg, s.type, s.level, level, rec);
       s.stream.write(s.raw ? rec : str);
     }
   }
-
   return str;
 };
 
@@ -941,21 +863,17 @@ Logger.prototype._emit = function(rec, noemit) {
  * provided to the a log emitter.
  */
 function mkRecord(log, minLevel, args) {
-  var excludeFields, fields, msgArgs;
+  let excludeFields, fields, msgArgs;
   if (args[0] instanceof Error) {
     // `log.<level>(err, ...)`
     fields = {
       // Use this Logger's err serializer, if defined.
-      err: log.serializers && log.serializers.err
+      err: (log.serializers && log.serializers.err)
         ? log.serializers.err(args[0])
         : Logger.stdSerializers.err(args[0])
     };
-    excludeFields = {err: true};
-    if (args.length === 1) {
-      msgArgs = [fields.err.message];
-    } else {
-      msgArgs = args.slice(1);
-    }
+    excludeFields = { err: true };
+    msgArgs = (args.length === 1) ? [fields.err.message] : args.slice(1);
   } else if (typeof args[0] !== 'object' || Array.isArray(args[0])) {
     // `log.<level>(msg, ...)`
     fields = null;
@@ -976,26 +894,21 @@ function mkRecord(log, minLevel, args) {
   }
 
   // Build up the record object.
-  var rec = objCopy(log.fields);
-  // eslint-disable-next-line no-unused-vars
-  var level = rec.level = minLevel;
-  var recFields = fields ? objCopy(fields) : null;
+  let rec = objCopy(log.fields);
+  rec.level = minLevel;
+  const recFields = fields ? objCopy(fields) : null;
   if (recFields) {
-    if (log.serializers) {
-      log._applySerializers(recFields, excludeFields);
-    }
-    Object.keys(recFields).forEach(function(k) {
-      rec[k] = recFields[k];
-    });
+    if (log.serializers) log._applySerializers(recFields, excludeFields);
+
+    Object.assign(rec, recFields);
   }
+
   rec.msg = format.apply(log, msgArgs);
-  if (!rec.time) {
-    rec.time = new Date();
-  }
+  if (!rec.time) rec.time = new Date();
+
   // Get call source info
-  if (log.src && !rec.src) {
-    rec.src = getCaller3Info();
-  }
+  if (log.src && !rec.src) rec.src = getCaller3Info();
+
   rec.v = LOG_VERSION;
 
   return rec;
@@ -1018,9 +931,9 @@ function mkProbeArgs(str, log, minLevel, msgArgs) {
  */
 function mkLogEmitter(minLevel) {
   return function() {
-    var log = this;
-    var str = null;
-    var rec = null;
+    const log = this;
+    let str = null;
+    let rec = null;
 
     if (!this._emit) {
 
@@ -1030,32 +943,32 @@ function mkLogEmitter(minLevel) {
        * See <https://github.com/trentm/node-bunyan/issues/100> for
        * an example of how this can happen.
        */
-      var dedupKey = 'unbound';
+      const dedupKey = 'unbound';
       if (!_haveWarned[dedupKey]) {
-        var caller = getCaller3Info();
-        _warn(format('bunyan usage error: %s:%s: attempt to log '
-                    + 'with an unbound log method: `this` is: %s',
-        caller.file, caller.line, util.inspect(this)),
-        dedupKey);
+        const caller = getCaller3Info();
+        _warn(
+          format(
+            'bunyan usage error: %s:%s: attempt to log with an unbound log method: `this` is: %s',
+            caller.file,
+            caller.line,
+            util.inspect(this)
+          ),
+          dedupKey
+        );
       }
       return;
     } else if (arguments.length === 0) { // `log.<level>()`
       return this._level <= minLevel;
     }
 
-    var msgArgs = new Array(arguments.length);
-    for (var i = 0; i < msgArgs.length; ++i) {
-      msgArgs[i] = arguments[i];
-    }
+    const msgArgs = Object.values(arguments);
 
     if (this._level <= minLevel) {
       rec = mkRecord(log, minLevel, msgArgs);
       str = this._emit(rec);
     }
 
-    if (probes) {
-      probes[minLevel].fire(mkProbeArgs, str, log, minLevel, msgArgs);
-    }
+    if (probes) probes[minLevel].fire(mkProbeArgs, str, log, minLevel, msgArgs);
   };
 }
 
@@ -1093,7 +1006,7 @@ Logger.prototype.fatal = mkLogEmitter(FATAL);
 Logger.stdSerializers = {};
 
 // Serialize an HTTP request.
-Logger.stdSerializers.req = function(req) {
+Logger.stdSerializers.req = (req) => {
   if (!req || !req.connection) return req;
   return {
     method: req.method,
@@ -1110,7 +1023,7 @@ Logger.stdSerializers.req = function(req) {
 };
 
 // Serialize an HTTP response.
-Logger.stdSerializers.res = function(res) {
+Logger.stdSerializers.res = (res) => {
   if (!res || !res.statusCode) return res;
   return {
     statusCode: res.statusCode,
@@ -1129,12 +1042,10 @@ Logger.stdSerializers.res = function(res) {
  * https://github.com/davepacheco/node-extsprintf/blob/master/lib/extsprintf.js
  */
 function getFullErrorStack(ex) {
-  var ret = ex.stack || ex.toString();
+  let ret = ex.stack || ex.toString();
   if (ex.cause && typeof ex.cause === 'function') {
-    var cex = ex.cause();
-    if (cex) {
-      ret += '\nCaused by: ' + getFullErrorStack(cex);
-    }
+    const cex = ex.cause();
+    if (cex) ret += '\nCaused by: ' + getFullErrorStack(cex);
   }
   return ret;
 }
@@ -1142,29 +1053,24 @@ function getFullErrorStack(ex) {
 // Serialize an Error object
 // (Core error properties are enumerable in node 0.4, not in 0.6).
 // eslint-disable-next-line no-unused-vars
-var errSerializer = Logger.stdSerializers.err = function(err) {
+var errSerializer = Logger.stdSerializers.err = (err) => {
   if (!err || !err.stack) return err;
-  var obj = {
+  return {
     message: err.message,
     name: err.name,
     stack: getFullErrorStack(err),
     code: err.code,
     signal: err.signal
   };
-  return obj;
 };
 
 
 // A JSON stringifier that handles cycles safely - tracks seen values in a Set.
 function safeCyclesSet() {
-  var seen = new Set();
-  return function(key, val) {
-    if (!val || typeof val !== 'object') {
-      return val;
-    }
-    if (seen.has(val)) {
-      return '[Circular]';
-    }
+  const seen = new Set();
+  return (key, val) => {
+    if (!val || typeof val !== 'object') return val;
+    if (seen.has(val)) return '[Circular]';
     seen.add(val);
     return val;
   };
@@ -1179,14 +1085,10 @@ function safeCyclesSet() {
  * when Set is not available.
  */
 function safeCyclesArray() {
-  var seen = [];
-  return function(key, val) {
-    if (!val || typeof val !== 'object') {
-      return val;
-    }
-    if (seen.indexOf(val) !== -1) {
-      return '[Circular]';
-    }
+  let seen = [];
+  return (key, val) => {
+    if (!val || typeof val !== 'object') return val;
+    if (seen.indexOf(val) !== -1) return '[Circular]';
     seen.push(val);
     return val;
   };
@@ -1200,7 +1102,7 @@ function safeCyclesArray() {
  * Choose the best safe cycle function from what is available - see
  * trentm/node-bunyan#445.
  */
-var safeCycles = typeof Set !== 'undefined' ? safeCyclesSet : safeCyclesArray;
+const safeCycles = typeof Set !== 'undefined' ? safeCyclesSet : safeCyclesArray;
 
 /**
  * A fast JSON.stringify that handles cycles and getter exceptions (when
@@ -1217,37 +1119,47 @@ function fastAndSafeJsonStringify(rec) {
     try {
       return JSON.stringify(rec, safeCycles());
     } catch (e) {
-      if (safeJsonStringify) {
-        return safeJsonStringify(rec);
-      }
+      if (safeJsonStringify) return safeJsonStringify(rec);
+
       var dedupKey = e.stack.split(/\n/g, 3).join('\n');
-      _warn('bunyan: ERROR: Exception in '
-                    + '`JSON.stringify(rec)`. You can install the '
-                    + '"safe-json-stringify" module to have Bunyan fallback '
-                    + 'to safer stringification. Record:\n'
-                    + _indent(format('%s\n%s', util.inspect(rec), e.stack)),
-      dedupKey);
-      return format('(Exception in JSON.stringify(rec): %j. '
-                    + 'See stderr for details.)', e.message);
+      _warn(
+        'bunyan: ERROR: Exception in '
+          + '`JSON.stringify(rec)`. You can install the '
+          + '"safe-json-stringify" module to have Bunyan fallback '
+          + 'to safer stringification. Record:\n'
+          + _indent(format('%s\n%s', util.inspect(rec), e.stack)),
+        dedupKey
+      );
+      return format('(Exception in JSON.stringify(rec): %j. See stderr for details.)', e.message);
 
     }
   }
 }
 
 
-var RotatingFileStream = null;
+let RotatingFileStream = null;
 if (mv) {
-
-  RotatingFileStream = function RotatingFileStream(options) {
+  RotatingFileStream = function(options) {
     this.path = options.path;
-
     this.count = options.count == null ? 10 : options.count;
-    assert.equal(typeof this.count, 'number',
-      format('rotating-file stream "count" is not a number: %j (%s) in %j',
-        this.count, typeof this.count, this));
-    assert.ok(this.count >= 0,
-      format('rotating-file stream "count" is not >= 0: %j in %j',
-        this.count, this));
+    assert.equal(
+      typeof this.count,
+      'number',
+      format(
+        'rotating-file stream "count" is not a number: %j (%s) in %j',
+        this.count,
+        typeof this.count,
+        this
+      )
+    );
+    assert.ok(
+      this.count >= 0,
+      format(
+        'rotating-file stream "count" is not >= 0: %j in %j',
+        this.count,
+        this
+      )
+    );
 
     // Parse `options.period`.
     if (options.period) {
@@ -1259,17 +1171,16 @@ if (mv) {
       //    y   years (at the start of Jan 1st)
       // with special values 'hourly' (1h), 'daily' (1d), "weekly" (1w),
       // 'monthly' (1m) and 'yearly' (1y)
-      var period = {
+      const period = {
         'hourly': '1h',
         'daily': '1d',
         'weekly': '1w',
         'monthly': '1m',
         'yearly': '1y'
       }[options.period] || options.period;
-      var m = /^([1-9][0-9]*)([hdwmy]|ms)$/.exec(period);
-      if (!m) {
-        throw new Error(format('invalid period: "%s"', options.period));
-      }
+      const m = /^([1-9][0-9]*)([hdwmy]|ms)$/.exec(period);
+      if (!m) throw new Error(format('invalid period: "%s"', options.period));
+
       this.periodNum = Number(m[1]);
       this.periodScope = m[2];
     } else {
@@ -1277,16 +1188,16 @@ if (mv) {
       this.periodScope = 'd';
     }
 
-    var lastModified = null;
+    let lastModified = null;
     try {
-      var fileInfo = fs.statSync(this.path);
+      const fileInfo = fs.statSync(this.path);
       lastModified = fileInfo.mtime.getTime();
     } catch (err) {
       // file doesn't exist
     }
-    var rotateAfterOpen = false;
+    let rotateAfterOpen = false;
     if (lastModified) {
-      var lastRotTime = this._calcRotTime(0);
+      const lastRotTime = this._calcRotTime(0);
       if (lastModified < lastRotTime) {
         rotateAfterOpen = true;
       }
@@ -1308,8 +1219,7 @@ if (mv) {
     //                          prior art? Want to avoid ':' in
     //                          filenames (illegal on Windows for one).
 
-    this.stream = fs.createWriteStream(this.path,
-      {flags: 'a', encoding: 'utf8'});
+    this.stream = fs.createWriteStream(this.path, { flags: 'a', encoding: 'utf8' });
 
     this.rotQueue = [];
     this.rotating = false;
@@ -1323,7 +1233,7 @@ if (mv) {
 
   util.inherits(RotatingFileStream, EventEmitter);
 
-  RotatingFileStream.prototype._debug = function() {
+  RotatingFileStream.prototype._debug = () => {
     // Set this to `true` to add debug logging.
     // eslint-disable-next-line no-constant-condition
     if (false) {
@@ -1345,20 +1255,21 @@ if (mv) {
   };
 
   RotatingFileStream.prototype._setRotationTimer = function() {
-    var self = this;
-    var delay = this.rotAt - Date.now();
+    const self = this;
+    let delay = this.rotAt - Date.now();
     // Cap timeout to Node's max setTimeout, see
     // <https://github.com/joyent/node/issues/8656>.
-    var TIMEOUT_MAX = 2147483647; // 2^31-1
+    const TIMEOUT_MAX = 2147483647; // 2^31-1
     if (delay > TIMEOUT_MAX) {
       delay = TIMEOUT_MAX;
     }
     this.timeout = setTimeout(
-      function() {
+      () => {
         self._debug('_setRotationTimer timeout -> call rotate()');
         self.rotate();
       },
-      delay);
+      delay
+    );
     if (typeof this.timeout.unref === 'function') {
       this.timeout.unref();
     }
@@ -1366,11 +1277,11 @@ if (mv) {
 
   RotatingFileStream.prototype._calcRotTime = function _calcRotTime(periodOffset) {
     this._debug('_calcRotTime: %s%s', this.periodNum, this.periodScope);
-    var d = new Date();
+    const d = new Date();
 
     this._debug('  now local: %s', d);
     this._debug('    now utc: %s', d.toISOString());
-    var rotAt;
+    let rotAt;
     switch (this.periodScope) {
       case 'ms':
       // Hidden millisecond period for debugging.
@@ -1385,55 +1296,76 @@ if (mv) {
           rotAt = this.rotAt + this.periodNum * 60 * 60 * 1000 * periodOffset;
         } else {
         // First time: top of the next hour.
-          rotAt = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(),
-            d.getUTCDate(), d.getUTCHours() + periodOffset);
+          rotAt = Date.UTC(
+            d.getUTCFullYear(),
+            d.getUTCMonth(),
+            d.getUTCDate(),
+            d.getUTCHours() + periodOffset
+          );
         }
         break;
       case 'd':
         if (this.rotAt) {
-          rotAt = this.rotAt + this.periodNum * 24 * 60 * 60 * 1000
-                * periodOffset;
+          rotAt = this.rotAt + this.periodNum * 24 * 60 * 60 * 1000 * periodOffset;
         } else {
         // First time: start of tomorrow (i.e. at the coming midnight) UTC.
-          rotAt = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(),
-            d.getUTCDate() + periodOffset);
+          rotAt = Date.UTC(
+            d.getUTCFullYear(),
+            d.getUTCMonth(),
+            d.getUTCDate() + periodOffset
+          );
         }
         break;
       case 'w':
       // Currently, always on Sunday morning at 00:00:00 (UTC).
         if (this.rotAt) {
-          rotAt = this.rotAt + this.periodNum * 7 * 24 * 60 * 60 * 1000
-                * periodOffset;
+          rotAt = this.rotAt + this.periodNum * 7 * 24 * 60 * 60 * 1000 * periodOffset;
         } else {
         // First time: this coming Sunday.
-          var dayOffset = 7 - d.getUTCDay();
+          let dayOffset = 7 - d.getUTCDay();
           if (periodOffset < 1) {
             dayOffset = -d.getUTCDay();
           }
           if (periodOffset > 1 || periodOffset < -1) {
             dayOffset += 7 * periodOffset;
           }
-          rotAt = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(),
-            d.getUTCDate() + dayOffset);
+          rotAt = Date.UTC(
+            d.getUTCFullYear(),
+            d.getUTCMonth(),
+            d.getUTCDate() + dayOffset
+          );
         }
         break;
       case 'm':
         if (this.rotAt) {
-          rotAt = Date.UTC(d.getUTCFullYear(),
-            d.getUTCMonth() + this.periodNum * periodOffset, 1);
+          rotAt = Date.UTC(
+            d.getUTCFullYear(),
+            d.getUTCMonth() + this.periodNum * periodOffset,
+            1
+          );
         } else {
         // First time: the start of the next month.
-          rotAt = Date.UTC(d.getUTCFullYear(),
-            d.getUTCMonth() + periodOffset, 1);
+          rotAt = Date.UTC(
+            d.getUTCFullYear(),
+            d.getUTCMonth() + periodOffset,
+            1
+          );
         }
         break;
       case 'y':
         if (this.rotAt) {
-          rotAt = Date.UTC(d.getUTCFullYear() + this.periodNum * periodOffset,
-            0, 1);
+          rotAt = Date.UTC(
+            d.getUTCFullYear() + this.periodNum * periodOffset,
+            0,
+            1
+          );
         } else {
         // First time: the start of the next year.
-          rotAt = Date.UTC(d.getUTCFullYear() + periodOffset, 0, 1);
+          rotAt = Date.UTC(
+            d.getUTCFullYear() + periodOffset,
+            0,
+            1
+          );
         }
         break;
       default:
@@ -1441,9 +1373,8 @@ if (mv) {
     }
 
     if (this._debug()) {
-      this._debug('  **rotAt**: %s (utc: %s)', rotAt,
-        new Date(rotAt).toUTCString());
-      var now = Date.now();
+      this._debug('  **rotAt**: %s (utc: %s)', rotAt, new Date(rotAt).toUTCString());
+      const now = Date.now();
       this._debug('        now: %s (%sms == %smin == %sh to go)',
         now,
         rotAt - now,
@@ -1455,13 +1386,11 @@ if (mv) {
 
   RotatingFileStream.prototype.rotate = function rotate() {
     // XXX What about shutdown?
-    var self = this;
+    const self = this;
 
     // If rotation period is > ~25 days, we have to break into multiple
     // setTimeout's. See <https://github.com/joyent/node/issues/8656>.
-    if (self.rotAt && self.rotAt > Date.now()) {
-      return self._setRotationTimer();
-    }
+    if (self.rotAt && self.rotAt > Date.now()) return self._setRotationTimer();
 
     this._debug('rotate');
     if (self.rotating) {
@@ -1472,7 +1401,7 @@ if (mv) {
     self.stream.end(); // XXX can do moves sync after this? test at high rate
 
     function del() {
-      var toDel = self.path + '.' + String(n - 1);
+      let toDel = self.path + '.' + String(n - 1);
       if (n === 0) {
         toDel = self.path;
       }
@@ -1488,19 +1417,19 @@ if (mv) {
       if (self.count === 0 || n < 0) {
         return finish();
       }
-      var before = self.path;
-      var after = self.path + '.' + String(n);
+      let before = self.path;
+      const after = self.path + '.' + String(n);
       if (n > 0) {
         before += '.' + String(n - 1);
       }
       n -= 1;
       // eslint-disable-next-line node/no-deprecated-api
-      fs.exists(before, function(exists) {
+      fs.exists(before, (exists) =>{
         if (!exists) {
           moves();
         } else {
           self._debug('  mv %s %s', before, after);
-          mv(before, after, function(mvErr) {
+          mv(before, after, (mvErr) => {
             if (mvErr) {
               self.emit('error', mvErr);
               finish(); // XXX finish here?
@@ -1514,11 +1443,10 @@ if (mv) {
 
     function finish() {
       self._debug('  open %s', self.path);
-      self.stream = fs.createWriteStream(self.path,
-        {flags: 'a', encoding: 'utf8'});
-      var q = self.rotQueue, len = q.length;
-      for (var i = 0; i < len; i++) {
-        self.stream.write(q[i]);
+      self.stream = fs.createWriteStream(self.path, { flags: 'a', encoding: 'utf8' });
+
+      for (const q of self.rotQueue) {
+        self.stream.write(q);
       }
       self.rotQueue = [];
       self.rotating = false;
@@ -1526,20 +1454,19 @@ if (mv) {
       self._setupNextRot();
     }
 
-    var n = this.count;
+    const n = this.count;
     del();
   };
 
-  RotatingFileStream.prototype.write = function write(s) {
+  RotatingFileStream.prototype.write = function(s) {
     if (this.rotating) {
       this.rotQueue.push(s);
       return false;
     }
     return this.stream.write(s);
-
   };
 
-  RotatingFileStream.prototype.end = function end(s) {
+  RotatingFileStream.prototype.end = function(s) {
     this.stream.end();
   };
 
@@ -1612,7 +1539,7 @@ module.exports.nameFromLevel = nameFromLevel;
 module.exports.VERSION = VERSION;
 module.exports.LOG_VERSION = LOG_VERSION;
 
-module.exports.createLogger = function createLogger(options) {
+module.exports.createLogger = function(options) {
   return new Logger(options);
 };
 

--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -33,7 +33,7 @@ let xxx, safeJsonStringify, mv, RotatingFileStream;
 
 if (INTERNAL_DEBUG) {
   xxx = (s, ...rest) => {
-    const args = ['XXX: ' + s].concat(rest);
+    const args = [`XXX: ${s}`].concat(rest);
     console.error.apply(this, args);
   };
 } else {
@@ -135,7 +135,7 @@ function getCaller3Info() {
 function _indent(s, indent) {
   if (!indent) indent = '    ';
   const lines = s.split(/\r?\n/g);
-  return indent + lines.join('\n' + indent);
+  return indent + lines.join(`\n${indent}`);
 }
 
 
@@ -155,7 +155,7 @@ function _warn(msg, dedupKey) {
     if (_warned[dedupKey]) return;
     _warned[dedupKey] = true;
   }
-  process.stderr.write(msg + '\n');
+  process.stderr.write(`${msg}\n`);
 }
 function _haveWarned(dedupKey) {
   return _warned[dedupKey];
@@ -609,7 +609,7 @@ if (mv) {
     self.stream.end(); // XXX can do moves sync after this? test at high rate
 
     function del(n) {
-      let toDel = self.path + '.' + String(n - 1);
+      let toDel = `${self.path}.${String(n - 1)}`;
       if (n === 0) {
         toDel = self.path;
       }
@@ -626,9 +626,9 @@ if (mv) {
         return finish();
       }
       let before = self.path;
-      const after = self.path + '.' + String(n);
+      const after = `${self.path}.${String(n)}`;
       if (n > 0) {
-        before += '.' + String(n - 1);
+        before += `.${String(n - 1)}`;
       }
       n -= 1;
 
@@ -686,7 +686,7 @@ if (mv) {
     this.stream.destroySoon();
   };
 
-} /* if (mv) */
+}/* if (mv) */
 
 /**
  * Add a stream
@@ -732,7 +732,7 @@ Logger.prototype.addStream = function addStream(s, defaultLevel) {
 
   switch (s.type) {
     case 'stream':
-      assert.ok(isWritable(s.stream), '"stream" stream is not writable: ' + inspect(s.stream));
+      assert.ok(isWritable(s.stream), `"stream" stream is not writable: ${inspect(s.stream)}`);
 
       if (!s.closeOnExit) s.closeOnExit = false;
       break;
@@ -944,12 +944,12 @@ Logger.prototype.level = function level(value) {
 Logger.prototype.levels = function levels(name, value) {
   if (name === undefined) {
     assert.equal(value, undefined);
-    return this.streams.map((s) => s.level);
+    return this.streams.map(({level}) => level);
   }
   let stream;
   if (typeof name === 'number') {
     stream = this.streams[name];
-    if (stream === undefined) throw new Error('invalid stream index: ' + name);
+    if (stream === undefined) throw new Error(`invalid stream index: ${name}`);
   } else {
     for (const s of this.streams) {
       if (s.name === name) {
@@ -1022,7 +1022,7 @@ Logger.prototype._emit = function(rec, noemit) {
   // Stringify the object (creates a warning str on error).
   let str;
   if (noemit || this.haveNonRawStreams) {
-    str = fastAndSafeJsonStringify(rec) + '\n';
+    str = `${fastAndSafeJsonStringify(rec)}\n`;
   }
 
   if (noemit) return str;
@@ -1043,7 +1043,9 @@ Logger.prototype._emit = function(rec, noemit) {
  * provided to the a log emitter.
  */
 function mkRecord(log, minLevel, args) {
-  let excludeFields, fields, msgArgs;
+  let excludeFields,
+    fields,
+    msgArgs;
   if (args[0] instanceof Error) {
     // `log.<level>(err, ...)`
     fields = {
@@ -1099,7 +1101,7 @@ function mkRecord(log, minLevel, args) {
  * creator of `log.info`, `log.error`, etc.
  */
 function mkLogEmitter(minLevel) {
-  return function() {
+  return function(...args) {
     const log = this;
     // eslint-disable-next-line no-unused-vars
     let str = null; // Without this line the test won't passed
@@ -1119,11 +1121,11 @@ function mkLogEmitter(minLevel) {
         _warn(`bunyan usage error: ${caller.file}:${caller.line}: attempt to log with an unbound log method: \`this\` is: ${inspect(this)}`, dedupKey);
       }
       return;
-    } else if (arguments.length === 0) { // `log.<level>()`
+    } else if (args.length === 0) { // `log.<level>()`
       return this._level <= minLevel;
     }
 
-    const msgArgs = Object.values(arguments);
+    const msgArgs = Object.values(args);
 
     if (this._level <= minLevel) {
       rec = mkRecord(log, minLevel, msgArgs);
@@ -1205,7 +1207,7 @@ function getFullErrorStack(ex) {
   let ret = ex.stack || ex.toString();
   if (ex.cause && typeof ex.cause === 'function') {
     const cex = ex.cause();
-    if (cex) ret += '\nCaused by: ' + getFullErrorStack(cex);
+    if (cex) ret += `\nCaused by: ${getFullErrorStack(cex)}`;
   }
   return ret;
 }
@@ -1247,7 +1249,7 @@ function safeCyclesArray() {
   let seen = [];
   return (key, val) => {
     if (!val || typeof val !== 'object') return val;
-    if (seen.indexOf(val) !== -1) return '[Circular]';
+    if (seen.includes(val)) return '[Circular]';
     seen.push(val);
     return val;
   };
@@ -1282,11 +1284,7 @@ function fastAndSafeJsonStringify(rec) {
 
       const dedupKey = e.stack.split(/\n/g, 3).join('\n');
       _warn(
-        'bunyan: ERROR: Exception in '
-          + '`JSON.stringify(rec)`. You can install the '
-          + '"safe-json-stringify" module to have Bunyan fallback '
-          + 'to safer stringification. Record:\n'
-          + _indent(`${inspect(rec)}\n${e.stack}`),
+        `bunyan: ERROR: Exception in \`JSON.stringify(rec)\`. You can install the "safe-json-stringify" module to have Bunyan fallback to safer stringification. Record:\n${_indent(`${inspect(rec)}\n${e.stack}`)}`,
         dedupKey
       );
       return `(Exception in JSON.stringify(rec): ${e.message}. See stderr for details.)`;
@@ -1322,8 +1320,8 @@ RingBuffer.prototype.write = function(record) {
   return true;
 };
 
-RingBuffer.prototype.end = function() {
-  if (arguments.length > 0) this.write.apply(this, Array.prototype.slice.call(arguments));
+RingBuffer.prototype.end = function(...args) {
+  if (args.length > 0) this.write.apply(this, Array.prototype.slice.call(args));
   this.writable = false;
 };
 
@@ -1354,9 +1352,7 @@ module.exports.nameFromLevel = nameFromLevel;
 module.exports.VERSION = VERSION;
 module.exports.LOG_VERSION = LOG_VERSION;
 
-module.exports.createLogger = function(options) {
-  return new Logger(options);
-};
+module.exports.createLogger = function(options) { return new Logger(options); };
 
 module.exports.RingBuffer = RingBuffer;
 module.exports.RotatingFileStream = RotatingFileStream;

--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -38,14 +38,6 @@ xxx = () => {}; // comment out to turn on debug logging
 
 const os = require('os');
 const fs = require('fs');
-let dtrace;
-
-try {
-  // eslint-disable-next-line node/no-missing-require
-  dtrace = require('dtrace-provider');
-} catch (e) {
-  dtrace = null;
-}
 
 const { format, inspect, inherits } = require('util');
 const assert = require('assert');
@@ -178,11 +170,6 @@ ConsoleRawStream.prototype.write = (rec) => {
     console.error(rec);
   }
 };
-
-
-// Dtrace probes.
-let dtp;
-const probes = dtrace && {};
 
 /**
  * Resolve a level number, name (upper or lowercase) to a level number value.
@@ -320,16 +307,6 @@ function Logger(options, _childOptions, _childSimple) {
     this.serializers = null;
     this.src = false;
     this.fields = {};
-  }
-
-  if (!dtp && dtrace) {
-    dtp = dtrace.createDTraceProvider('bunyan');
-
-    for (const level in levelFromName) {
-      probes[levelFromName[level]] = dtp.addProbe('log-' + level, 'char *');
-    }
-
-    dtp.enable();
   }
 
   // Handle *config* options (i.e. options that are not just plain data
@@ -1117,17 +1094,6 @@ function mkRecord(log, minLevel, args) {
   return rec;
 }
 
-
-/**
- * Build an array that dtrace-provider can use to fire a USDT probe. If we've
- * already built the appropriate string, we use it. Otherwise, build the
- * record object and stringify it.
- */
-function mkProbeArgs(str, log, minLevel, msgArgs) {
-  return [str || log._emit(mkRecord(log, minLevel, msgArgs), true)];
-}
-
-
 /**
  * Build a log emitter function for level minLevel. I.e. this is the
  * creator of `log.info`, `log.error`, etc.
@@ -1135,7 +1101,8 @@ function mkProbeArgs(str, log, minLevel, msgArgs) {
 function mkLogEmitter(minLevel) {
   return function() {
     const log = this;
-    let str = null;
+    // eslint-disable-next-line no-unused-vars
+    let str = null; // Without this line the test won't passed
     let rec = null;
 
     if (!this._emit) {
@@ -1162,8 +1129,6 @@ function mkLogEmitter(minLevel) {
       rec = mkRecord(log, minLevel, msgArgs);
       str = this._emit(rec);
     }
-
-    if (probes) probes[minLevel].fire(mkProbeArgs, str, log, minLevel, msgArgs);
   };
 }
 

--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -36,8 +36,8 @@ let xxx = (s) => { // internal dev/debug logging
 };
 xxx = () => {}; // comment out to turn on debug logging
 
-let os = require('os');
-let fs = require('fs');
+const os = require('os');
+const fs = require('fs');
 let dtrace;
 
 try {
@@ -500,7 +500,7 @@ if (mv) {
       if (arguments.length === 0) {
         return true;
       }
-      var args = Array.prototype.slice.call(arguments);
+      let args = Array.prototype.slice.call(arguments);
       args[0] = '[' + new Date().toISOString() + ', '
             + this.path + '] ' + args[0];
       console.log.apply(this, args);
@@ -1273,7 +1273,7 @@ function getFullErrorStack(ex) {
 // Serialize an Error object
 // (Core error properties are enumerable in node 0.4, not in 0.6).
 // eslint-disable-next-line no-unused-vars
-var errSerializer = Logger.stdSerializers.err = (err) => {
+const errSerializer = Logger.stdSerializers.err = (err) => {
   if (!err || !err.stack) return err;
   return {
     message: err.message,

--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -27,12 +27,18 @@ const VERSION = '1.8.10';
  */
 const LOG_VERSION = 0;
 
+const INTERNAL_DEBUG = false; // Set this to true to enable internal dev/logging.
 
-let xxx = (s) => { // internal dev/debug logging
-  const args = ['XXX: ' + s].concat(Array.prototype.slice.call(arguments, 1));
-  console.error.apply(this, args);
-};
-xxx = () => {}; // comment out to turn on debug logging
+let xxx, safeJsonStringify, mv, RotatingFileStream;
+
+if (INTERNAL_DEBUG) {
+  xxx = (s) => { // internal dev/debug logging
+    const args = ['XXX: ' + s].concat(Array.prototype.slice.call(arguments, 1));
+    console.error.apply(this, args);
+  };
+} else {
+  xxx = () => { };
+}
 
 const os = require('os');
 const fs = require('fs');
@@ -41,8 +47,6 @@ const { format, inspect, inherits } = require('util');
 const assert = require('assert');
 const EventEmitter = require('events').EventEmitter;
 const stream = require('stream');
-
-let safeJsonStringify, mv, RotatingFileStream;
 
 try {
   safeJsonStringify = require('safe-json-stringify');
@@ -157,7 +161,7 @@ function _haveWarned(dedupKey) {
   return _warned[dedupKey];
 }
 
-function ConsoleRawStream() {}
+function ConsoleRawStream() { }
 ConsoleRawStream.prototype.write = (rec) => {
   if (rec.level < INFO) {
     console.log(rec);
@@ -448,9 +452,7 @@ if (mv) {
   inherits(RotatingFileStream, EventEmitter);
 
   RotatingFileStream.prototype._debug = () => {
-    // Set this to `true` to add debug logging.
-    // eslint-disable-next-line no-constant-condition
-    if (false) {
+    if (INTERNAL_DEBUG) {
       if (arguments.length === 0) return true;
       let args = Array.prototype.slice.call(arguments);
       args[0] = `[${new Date().toISOString()}, ${this.path}] ${args[0]}`;
@@ -494,7 +496,7 @@ if (mv) {
     let rotAt;
     switch (this.periodScope) {
       case 'ms':
-      // Hidden millisecond period for debugging.
+        // Hidden millisecond period for debugging.
         if (this.rotAt) {
           rotAt = this.rotAt + (this.periodNum * periodOffset);
         } else {
@@ -505,7 +507,7 @@ if (mv) {
         if (this.rotAt) {
           rotAt = this.rotAt + (this.periodNum * 60 * 60 * 1000 * periodOffset);
         } else {
-        // First time: top of the next hour.
+          // First time: top of the next hour.
           rotAt = Date.UTC(
             d.getUTCFullYear(),
             d.getUTCMonth(),
@@ -518,7 +520,7 @@ if (mv) {
         if (this.rotAt) {
           rotAt = this.rotAt + (this.periodNum * 24 * 60 * 60 * 1000 * periodOffset);
         } else {
-        // First time: start of tomorrow (i.e. at the coming midnight) UTC.
+          // First time: start of tomorrow (i.e. at the coming midnight) UTC.
           rotAt = Date.UTC(
             d.getUTCFullYear(),
             d.getUTCMonth(),
@@ -527,11 +529,11 @@ if (mv) {
         }
         break;
       case 'w':
-      // Currently, always on Sunday morning at 00:00:00 (UTC).
+        // Currently, always on Sunday morning at 00:00:00 (UTC).
         if (this.rotAt) {
           rotAt = this.rotAt + (this.periodNum * 7 * 24 * 60 * 60 * 1000 * periodOffset);
         } else {
-        // First time: this coming Sunday.
+          // First time: this coming Sunday.
           let dayOffset = 7 - d.getUTCDay();
           if (periodOffset < 1) {
             dayOffset = -d.getUTCDay();
@@ -554,7 +556,7 @@ if (mv) {
             1
           );
         } else {
-        // First time: the start of the next month.
+          // First time: the start of the next month.
           rotAt = Date.UTC(
             d.getUTCFullYear(),
             d.getUTCMonth() + periodOffset,
@@ -570,7 +572,7 @@ if (mv) {
             1
           );
         } else {
-        // First time: the start of the next year.
+          // First time: the start of the next year.
           rotAt = Date.UTC(
             d.getUTCFullYear() + periodOffset,
             0,
@@ -738,7 +740,7 @@ Logger.prototype.addStream = function addStream(s, defaultLevel) {
       if (s.reemitErrorEvents === undefined) s.reemitErrorEvents = true;
 
       if (!s.stream) {
-        s.stream = fs.createWriteStream(s.path, {flags: 'a', encoding: 'utf8'});
+        s.stream = fs.createWriteStream(s.path, { flags: 'a', encoding: 'utf8' });
         if (!s.closeOnExit) s.closeOnExit = true;
       } else {
         if (!s.closeOnExit) s.closeOnExit = false;

--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -109,8 +109,7 @@ function objCopy(obj) {
   } else if (Array.isArray(obj)) {
     return obj.slice();
   } else if (typeof obj === 'object') {
-    let copy = {};
-    Object.assign(copy, obj);
+    const copy = Object.assign({}, obj);
     return copy;
   }
   return obj;
@@ -679,9 +678,9 @@ if (mv) {
         before += '.' + String(n - 1);
       }
       n -= 1;
-      // eslint-disable-next-line node/no-deprecated-api
-      fs.exists(before, (exists) => {
-        if (!exists) {
+
+      fs.access(before, fs.constants.F_OK, err => {
+        if (err) {
           moves(n);
         } else {
           self._debug(`  mv ${before} ${after}`);
@@ -1032,7 +1031,7 @@ Logger.prototype._applySerializers = function(fields, excludeFields) {
 
   // Check each serializer against these (presuming number of serializers
   // is typically less than number of fields).
-  Object.keys(this.serializers).forEach(function(name) {
+  Object.keys(this.serializers).forEach((name) => {
     if (fields[name] === undefined || (excludeFields && excludeFields[name])) return;
 
     xxx('_applySerializers; apply to "%s" key', name);
@@ -1122,7 +1121,7 @@ function mkRecord(log, minLevel, args) {
   }
 
   // Build up the record object.
-  let rec = objCopy(log.fields);
+  const rec = objCopy(log.fields);
   rec.level = minLevel;
   const recFields = fields ? objCopy(fields) : null;
   if (recFields) {
@@ -1272,8 +1271,7 @@ function getFullErrorStack(ex) {
 
 // Serialize an Error object
 // (Core error properties are enumerable in node 0.4, not in 0.6).
-// eslint-disable-next-line no-unused-vars
-const errSerializer = Logger.stdSerializers.err = (err) => {
+Logger.stdSerializers.err = (err) => {
   if (!err || !err.stack) return err;
   return {
     message: err.message,
@@ -1341,7 +1339,7 @@ function fastAndSafeJsonStringify(rec) {
     } catch (e) {
       if (safeJsonStringify) return safeJsonStringify(rec);
 
-      var dedupKey = e.stack.split(/\n/g, 3).join('\n');
+      const dedupKey = e.stack.split(/\n/g, 3).join('\n');
       _warn(
         'bunyan: ERROR: Exception in '
           + '`JSON.stringify(rec)`. You can install the '

--- a/package.json
+++ b/package.json
@@ -36,15 +36,17 @@
     "moment": "^2.10.6"
   },
   "devDependencies": {
-    "nodeunit": "0.11",
     "ben": "0.0.0",
+    "eslint": "^6.3.0",
+    "eslint-config-hexo": "^3.0.0",
     "markdown-toc": "1.2.x",
-    "verror": "1.10.0",
-    "vasync": "2.2.0"
+    "nodeunit": "0.11",
+    "vasync": "2.2.0",
+    "verror": "1.10.0"
   },
   "scripts": {
-    "test": "make test"
+    "test": "make test",
+    "eslint": "eslint ./lib/bunyan.js"
   },
-  "dependencies": {
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
Only `lib/bunyan.js` is touched.

- Bring up eslint & eslint-config-hexo
- Update code style to make eslint happy
- Make code es6-fy
  - replace `var` with `const`, `let`
  - use arrow function
  - use `Object.assign`
  - use `for .. of`
  - replace most `utils.format` with template string

Since `hexo-bunyan` only need to support NodeJS environment, browser side parts of the codes have been removed as well.

Still, hexo-bunyan can not pass the test with `strict mode` enabled (there is a conversion to `this` object of `Logger class`). `/* eslint-disable strict */` have been added to bypass the eslint.
