### PR TITLE
refactor(buffer.test): es6-fy

### DIFF
--- a/test/buffer.test.js
+++ b/test/buffer.test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /*
  * Copyright (c) 2012 Trent Mick. All rights reserved.
  * Copyright (c) 2012 Joyent Inc. All rights reserved.
@@ -5,77 +7,59 @@
  * Test logging with (accidental) usage of buffers.
  */
 
-var util = require('util'),
-    inspect = util.inspect,
-    format = util.format;
-var bunyan = require('../lib/bunyan');
+const { format, inspect } = require('util');
+const { createLogger } = require('../lib/bunyan');
+const { join } = require('path');
 
 // node-tap API
-if (require.cache[__dirname + '/tap4nodeunit.js'])
-        delete require.cache[__dirname + '/tap4nodeunit.js'];
-var tap4nodeunit = require('./tap4nodeunit.js');
-var after = tap4nodeunit.after;
-var before = tap4nodeunit.before;
-var test = tap4nodeunit.test;
-
+if (require.cache[join(__dirname, '/tap4nodeunit.js')]) {
+  delete require.cache[join(__dirname, '/tap4nodeunit.js')];
+}
+const { test } = require('./tap4nodeunit.js');
 
 
 function Catcher() {
-    this.records = [];
+  this.records = [];
 }
-Catcher.prototype.write = function (record) {
-    this.records.push(record);
-}
+Catcher.prototype.write = function(record) {
+  this.records.push(record);
+};
 
-var catcher = new Catcher();
-var log = new bunyan.createLogger({
-    name: 'buffer.test',
-    streams: [
-        {
-            type: 'raw',
-            stream: catcher,
-            level: 'trace'
-        }
-    ]
+const catcher = new Catcher();
+const log = createLogger({
+  name: 'buffer.test',
+  streams: [
+    {
+      type: 'raw',
+      stream: catcher,
+      level: 'trace'
+    }
+  ]
 });
 
+test('log.info(BUFFER)', t => {
+  const b = Buffer.from('foo');
 
-test('log.info(BUFFER)', function (t) {
-    var b = new Buffer('foo');
+  ['trace',
+    'debug',
+    'info',
+    'warn',
+    'error',
+    'fatal'].forEach(lvl => {
+    log[lvl](b);
+    let rec = catcher.records[catcher.records.length - 1];
+    t.equal(rec.msg, inspect(b),
+      format('log.%s msg is inspect(BUFFER)', lvl));
+    t.ok(rec['0'] === undefined,
+      'no "0" array index key in record: ' + inspect(rec['0']));
+    t.ok(rec.parent === undefined,
+      'no "parent" array index key in record: ' + inspect(rec.parent));
 
-    ['trace',
-     'debug',
-     'info',
-     'warn',
-     'error',
-     'fatal'].forEach(function (lvl) {
-        log[lvl].call(log, b);
-        var rec = catcher.records[catcher.records.length - 1];
-        t.equal(rec.msg, inspect(b),
-            format('log.%s msg is inspect(BUFFER)', lvl));
-        t.ok(rec['0'] === undefined,
-            'no "0" array index key in record: ' + inspect(rec['0']));
-        t.ok(rec['parent'] === undefined,
-            'no "parent" array index key in record: ' + inspect(rec['parent']));
+    log[lvl](b, 'bar');
+    rec = catcher.records[catcher.records.length - 1];
+    t.equal(rec.msg, inspect(b) + ' bar', format(
+      'log.%s(BUFFER, "bar") msg is inspect(BUFFER) + " bar"', lvl));
+  });
 
-        log[lvl].call(log, b, 'bar');
-        var rec = catcher.records[catcher.records.length - 1];
-        t.equal(rec.msg, inspect(b) + ' bar', format(
-            'log.%s(BUFFER, "bar") msg is inspect(BUFFER) + " bar"', lvl));
-    });
-
-    t.end();
+  t.end();
 });
-
-
-//test('log.info({buf: BUFFER})', function (t) {
-//  var b = new Buffer('foo');
-//
-//  // Really there isn't much Bunyan can do here. See
-//  // <https://github.com/joyent/node/issues/3905>. An unwelcome hack would
-//  // be to monkey-patch in Buffer.toJSON. Bletch.
-//  log.info({buf: b}, 'my message');
-//  var rec = catcher.records[catcher.records.length - 1];
-//
-//  t.end();
-//});


### PR DESCRIPTION
I initially thought Buffer -> Buffer.from was a low-hanging fruit, end up refactor the whole file :expressionless:

btw, I set [`mini`](https://github.com/hexojs/hexo-bunyan/tree/mini) as base branch.